### PR TITLE
[JBERET-84] Remove static instances of repository types from jberet-core

### DIFF
--- a/jberet-core/src/main/java/org/jberet/_private/BatchMessages.java
+++ b/jberet-core/src/main/java/org/jberet/_private/BatchMessages.java
@@ -86,8 +86,8 @@ public interface BatchMessages {
     @Message(id = 619, value = "Failed to inject value %s into field %s")
     BatchRuntimeException failToInjectProperty(@Cause Throwable th, String v, Field f);
 
-    @Message(id = 620, value = "Unrecognized job repository type %s")
-    BatchRuntimeException unrecognizedJobRepositoryType(String v);
+    // @Message(id = 620, value = "Unrecognized job repository type %s")
+    // BatchRuntimeException unrecognizedJobRepositoryType(String v);
 
     @Message(id = 621, value = "Failed to look up datasource by jndi name %s.")
     BatchRuntimeException failToLookupDataSource(@Cause Throwable cause, String dataSourceName);
@@ -142,6 +142,9 @@ public interface BatchMessages {
 
     @Message(id = 638, value = "Failed to get the script content from %s")
     BatchRuntimeException failToGetScriptContent(@Cause Throwable th, String scriptSrc);
+
+    @Message(id = 639, value = "A job repository is required")
+    BatchRuntimeException jobRepositoryRequired();
 
 
 }

--- a/jberet-core/src/main/java/org/jberet/operations/JobOperatorImpl.java
+++ b/jberet-core/src/main/java/org/jberet/operations/JobOperatorImpl.java
@@ -41,11 +41,11 @@ import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
+import org.jberet._private.BatchMessages;
 import org.jberet.creation.ArchiveXmlLoader;
 import org.jberet.creation.ArtifactFactoryWrapper;
 import org.jberet.job.model.Job;
 import org.jberet.repository.JobRepository;
-import org.jberet.repository.JobRepositoryFactory;
 import org.jberet.runtime.JobExecutionImpl;
 import org.jberet.runtime.JobInstanceImpl;
 import org.jberet.runtime.context.JobContextImpl;
@@ -67,7 +67,10 @@ public class JobOperatorImpl implements JobOperator {
             break;
         }
         artifactFactory = new ArtifactFactoryWrapper(batchEnvironment.getArtifactFactory());
-        repository = JobRepositoryFactory.getJobRepository(batchEnvironment);
+        repository = batchEnvironment.getJobRepository();
+        if (repository == null) {
+            throw BatchMessages.MESSAGES.jobRepositoryRequired();
+        }
     }
 
     @Override

--- a/jberet-core/src/main/java/org/jberet/repository/InMemoryRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/InMemoryRepository.java
@@ -19,22 +19,37 @@ import javax.batch.runtime.StepExecution;
 import org.jberet.runtime.JobExecutionImpl;
 import org.jberet.runtime.JobInstanceImpl;
 import org.jberet.runtime.StepExecutionImpl;
-import org.jberet.spi.BatchEnvironment;
 
 public final class InMemoryRepository extends AbstractRepository {
     private final AtomicLong jobInstanceIdSequence = new AtomicLong();
     private final AtomicLong jobExecutionIdSequence = new AtomicLong();
     private final AtomicLong stepExecutionIdSequence = new AtomicLong();
 
-    private InMemoryRepository() {
+    public InMemoryRepository() {
     }
 
     private static class Holder {
         private static final InMemoryRepository instance = new InMemoryRepository();
     }
 
-    static InMemoryRepository getInstance(final BatchEnvironment batchEnvironment) {
+    /**
+     * Gets a singleton instance of an in-memory job repository.
+     *
+     * @return an in-memory job repository
+     */
+    public static InMemoryRepository getInstance() {
         return Holder.instance;
+    }
+
+    /**
+     * Creates a new in-memory job repository.
+     * <p/>
+     * Use where multiple in-memory job repositories may be needed.
+     *
+     * @return a new in-memory job repository
+     */
+    public static InMemoryRepository create() {
+        return new InMemoryRepository();
     }
 
     @Override

--- a/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
@@ -40,7 +40,6 @@ import org.jberet.runtime.JobExecutionImpl;
 import org.jberet.runtime.JobInstanceImpl;
 import org.jberet.runtime.PartitionExecutionImpl;
 import org.jberet.runtime.StepExecutionImpl;
-import org.jberet.spi.BatchEnvironment;
 import org.jberet.util.BatchUtil;
 
 public final class JdbcRepository extends AbstractRepository {
@@ -89,7 +88,6 @@ public final class JdbcRepository extends AbstractRepository {
     private static final String INSERT_PARTITION_EXECUTION = "insert-partition-execution";
     private static final String UPDATE_PARTITION_EXECUTION = "update-partition-execution";
 
-    private static volatile JdbcRepository instance;
     private final Properties configProperties;
     private String dataSourceName;
     private DataSource dataSource;
@@ -99,21 +97,12 @@ public final class JdbcRepository extends AbstractRepository {
     private boolean isOracle;
     private int[] idIndexInOracle;
 
-    static JdbcRepository getInstance(final BatchEnvironment batchEnvironment) {
-        JdbcRepository result = instance;
-        if (result == null) {
-            synchronized (JdbcRepository.class) {
-                result = instance;
-                if (result == null) {
-                    instance = result = new JdbcRepository(batchEnvironment);
-                }
-            }
-        }
-        return result;
+    public static JdbcRepository create(final Properties configProperties) {
+        return new JdbcRepository(configProperties);
     }
 
-    private JdbcRepository(final BatchEnvironment batchEnvironment) {
-        configProperties = batchEnvironment.getBatchConfigurationProperties();
+    public JdbcRepository(final Properties configProperties) {
+        this.configProperties = configProperties;
         dataSourceName = configProperties.getProperty(DATASOURCE_JNDI_KEY);
         dbUrl = configProperties.getProperty(DB_URL_KEY);
         dbProperties = new Properties();

--- a/jberet-core/src/main/java/org/jberet/repository/JobRepositoryFactory.java
+++ b/jberet-core/src/main/java/org/jberet/repository/JobRepositoryFactory.java
@@ -12,46 +12,21 @@
 
 package org.jberet.repository;
 
-import java.lang.reflect.Method;
-import java.util.Properties;
-
-import org.jberet._private.BatchMessages;
 import org.jberet.spi.BatchEnvironment;
 
+/**
+ * @deprecated use the {@link org.jberet.spi.BatchEnvironment#getJobRepository()}
+ */
+@Deprecated
 public final class JobRepositoryFactory {
     public static final String JOB_REPOSITORY_TYPE_KEY = "job-repository-type";
     public static final String REPOSITORY_TYPE_IN_MEMORY = "in-memory";
     public static final String REPOSITORY_TYPE_JDBC = "jdbc";
     public static final String REPOSITORY_TYPE_MONGODB = "mongodb";
-
     private JobRepositoryFactory() {
     }
 
     public static JobRepository getJobRepository(final BatchEnvironment batchEnvironment) {
-        String repositoryType = null;
-        if (batchEnvironment != null) {
-            final Properties configProperties = batchEnvironment.getBatchConfigurationProperties();
-            repositoryType = configProperties.getProperty(JOB_REPOSITORY_TYPE_KEY);
-            if (repositoryType != null) {
-                repositoryType = repositoryType.trim();
-            }
-        }
-        if (repositoryType == null || repositoryType.isEmpty() || repositoryType.equalsIgnoreCase(REPOSITORY_TYPE_JDBC)) {
-            return JdbcRepository.getInstance(batchEnvironment);
-        } else if (repositoryType.equalsIgnoreCase(REPOSITORY_TYPE_IN_MEMORY)) {
-            return InMemoryRepository.getInstance(batchEnvironment);
-        } else if (repositoryType.equalsIgnoreCase(REPOSITORY_TYPE_MONGODB)) {
-            final String className = "org.jberet.repository.MongoRepository";
-            try {
-                final Class c = batchEnvironment.getClassLoader().loadClass(className);
-                final Method getInstanceMethod = c.getMethod("getInstance", new Class[]{BatchEnvironment.class});
-                final Object mongoRepository = getInstanceMethod.invoke(null, batchEnvironment);
-                return (JobRepository) mongoRepository;
-            } catch (final Exception e) {
-                throw BatchMessages.MESSAGES.failToCreateArtifact(e, className);
-            }
-        } else {
-            throw BatchMessages.MESSAGES.unrecognizedJobRepositoryType(repositoryType);
-        }
+        return batchEnvironment.getJobRepository();
     }
 }

--- a/jberet-core/src/main/java/org/jberet/repository/MongoRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/MongoRepository.java
@@ -39,33 +39,20 @@ import org.jberet.runtime.JobExecutionImpl;
 import org.jberet.runtime.JobInstanceImpl;
 import org.jberet.runtime.PartitionExecutionImpl;
 import org.jberet.runtime.StepExecutionImpl;
-import org.jberet.spi.BatchEnvironment;
 import org.jberet.util.BatchUtil;
 
 public final class MongoRepository extends AbstractRepository {
-    private static volatile MongoRepository instance;
-    private final Properties configProperties;
     private String dataSourceName;
     private String dbUrl;
     private MongoClient mongoClient;
     private DB db;
     private DBCollection seqCollection;
 
-    public static MongoRepository getInstance(final BatchEnvironment batchEnvironment) {
-        MongoRepository result = instance;
-        if (result == null) {
-            synchronized (MongoRepository.class) {
-                result = instance;
-                if (result == null) {
-                    instance = result = new MongoRepository(batchEnvironment);
-                }
-            }
-        }
-        return result;
+    public static MongoRepository create(final Properties configProperties) {
+        return new MongoRepository(configProperties);
     }
 
-    private MongoRepository(final BatchEnvironment batchEnvironment) {
-        configProperties = batchEnvironment.getBatchConfigurationProperties();
+    public MongoRepository(final Properties configProperties) {
         dataSourceName = configProperties.getProperty(JdbcRepository.DATASOURCE_JNDI_KEY);
         dbUrl = configProperties.getProperty(JdbcRepository.DB_URL_KEY);
 

--- a/jberet-core/src/main/java/org/jberet/spi/BatchEnvironment.java
+++ b/jberet-core/src/main/java/org/jberet/spi/BatchEnvironment.java
@@ -16,6 +16,14 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import javax.transaction.TransactionManager;
 
+import org.jberet.repository.JobRepository;
+
+/**
+ * Represents the environment for the batch runtime.
+ *
+ * @author Cheng Fang
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
 public interface BatchEnvironment {
     /**
      * Gets the class loader suitable for loading application classes and batch artifacts.
@@ -76,6 +84,13 @@ public interface BatchEnvironment {
      * @return a transaction manager for the environment
      */
     TransactionManager getTransactionManager();
+
+    /**
+     * Returns the job repository used for this environment.
+     *
+     * @return the job repository
+     */
+    JobRepository getJobRepository();
 
     /**
      * Gets configuration data for batch container.

--- a/jberet-core/src/test/java/org/jberet/test/JobRepositoryTest.java
+++ b/jberet-core/src/test/java/org/jberet/test/JobRepositoryTest.java
@@ -30,8 +30,8 @@ import javax.transaction.xa.XAResource;
 
 import org.jberet.creation.ArchiveXmlLoader;
 import org.jberet.job.model.Job;
+import org.jberet.repository.InMemoryRepository;
 import org.jberet.repository.JobRepository;
-import org.jberet.repository.JobRepositoryFactory;
 import org.jberet.spi.ArtifactFactory;
 import org.jberet.spi.BatchEnvironment;
 import org.junit.Assert;
@@ -147,13 +147,18 @@ public class JobRepositoryTest {
             }
 
             @Override
+            public JobRepository getJobRepository() {
+                return InMemoryRepository.getInstance();
+            }
+
+            @Override
             public Properties getBatchConfigurationProperties() {
                 final Properties props = new Properties();
                 //props.setProperty(JobRepositoryFactory.JOB_REPOSITORY_TYPE_KEY, JobRepositoryFactory.REPOSITORY_TYPE_JDBC);
                 return props;
             }
         };
-        repo = JobRepositoryFactory.getJobRepository(batchEnvironment);
+        repo = batchEnvironment.getJobRepository();
     }
 
     @Test

--- a/jberet-se/src/main/java/org/jberet/se/BatchSEEnvironment.java
+++ b/jberet-se/src/main/java/org/jberet/se/BatchSEEnvironment.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.transaction.TransactionManager;
 
+import org.jberet.repository.JobRepository;
 import org.jberet.se._private.SEBatchLogger;
 import org.jberet.spi.ArtifactFactory;
 import org.jberet.spi.BatchEnvironment;
@@ -37,9 +38,14 @@ import org.jberet.tx.LocalTransactionManager;
  * Represents the Java SE batch runtime environment and its services.
  */
 public final class BatchSEEnvironment implements BatchEnvironment {
+
     ExecutorService executorService;
 
     public static final String CONFIG_FILE_NAME = "jberet.properties";
+    public static final String JOB_REPOSITORY_TYPE_KEY = "job-repository-type";
+    public static final String REPOSITORY_TYPE_IN_MEMORY = "in-memory";
+    public static final String REPOSITORY_TYPE_JDBC = "jdbc";
+    public static final String REPOSITORY_TYPE_MONGODB = "mongodb";
 
     private final Properties configProperties;
     private final TransactionManager tm;
@@ -107,6 +113,11 @@ public final class BatchSEEnvironment implements BatchEnvironment {
     @Override
     public TransactionManager getTransactionManager() {
         return tm;
+    }
+
+    @Override
+    public JobRepository getJobRepository() {
+        return JobRepositoryFactory.getJobRepository(configProperties);
     }
 
     @Override

--- a/jberet-se/src/main/java/org/jberet/se/JobRepositoryFactory.java
+++ b/jberet-se/src/main/java/org/jberet/se/JobRepositoryFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.se;
+
+import java.util.Properties;
+
+import org.jberet.repository.InMemoryRepository;
+import org.jberet.repository.JdbcRepository;
+import org.jberet.repository.JobRepository;
+import org.jberet.repository.MongoRepository;
+import org.jberet.se._private.SEBatchLogger;
+
+/**
+ * Determines the {@link org.jberet.repository.JobRepository job repistory} to use.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class JobRepositoryFactory {
+
+    private static final JobRepositoryFactory INSTANCE = new JobRepositoryFactory();
+
+    private JobRepository jobRepository;
+
+    private JobRepositoryFactory() {
+    }
+
+    public static JobRepository getJobRepository(final Properties configProperties) {
+        String repositoryType = null;
+        if (configProperties != null) {
+            repositoryType = configProperties.getProperty(BatchSEEnvironment.JOB_REPOSITORY_TYPE_KEY);
+            if (repositoryType != null) {
+                repositoryType = repositoryType.trim();
+            }
+        }
+        JobRepository jobRepository;
+        synchronized (INSTANCE) {
+            jobRepository = INSTANCE.jobRepository;
+            if (repositoryType == null || repositoryType.equalsIgnoreCase(BatchSEEnvironment.REPOSITORY_TYPE_IN_MEMORY)) {
+                if (!(jobRepository instanceof InMemoryRepository)) {
+                    jobRepository = INSTANCE.jobRepository = InMemoryRepository.getInstance();
+                }
+            } else if (repositoryType.isEmpty() || repositoryType.equalsIgnoreCase(BatchSEEnvironment.REPOSITORY_TYPE_JDBC)) {
+                if (!(jobRepository instanceof JdbcRepository)) {
+                    jobRepository = INSTANCE.jobRepository = JdbcRepository.create(configProperties);
+                }
+            } else if (repositoryType.equalsIgnoreCase(BatchSEEnvironment.REPOSITORY_TYPE_MONGODB)) {
+                if (!(jobRepository instanceof MongoRepository)) {
+                    jobRepository = INSTANCE.jobRepository = MongoRepository.create(configProperties);
+                }
+            } else {
+                throw SEBatchLogger.LOGGER.unrecognizedJobRepositoryType(repositoryType);
+            }
+        }
+        return jobRepository;
+    }
+}

--- a/jberet-se/src/main/java/org/jberet/se/_private/SEBatchLogger.java
+++ b/jberet-se/src/main/java/org/jberet/se/_private/SEBatchLogger.java
@@ -28,4 +28,7 @@ public interface SEBatchLogger {
 
     @Message(id = 50002, value = "Failed to get a valid value for configuration property %s; current value is %s.")
     BatchRuntimeException failToGetConfigProperty(String propName, String value, @Cause Throwable throwable);
+
+    @Message(id = 50003, value = "Unrecognized job repository type %s")
+    BatchRuntimeException unrecognizedJobRepositoryType(String v);
 }


### PR DESCRIPTION
@chengfang I could use a review on this.

Removed static instances of `JobRepository` types. These could be a problem in an environment like WildFly that can be reloaded with new environment specific objects. For example the `JdbcRepository` could hold on to a `DataSource` that is no longer valid.

Make the `JobRepository` environment specific by making it part of the `BatchEnvironment` SPI.
