### PR TITLE
[JBERET-108] It hangs if the partition plan defines the number of threads as 0

### DIFF
--- a/jberet-core/src/main/java/org/jberet/runtime/runner/StepExecutionRunner.java
+++ b/jberet-core/src/main/java/org/jberet/runtime/runner/StepExecutionRunner.java
@@ -220,6 +220,7 @@ public final class StepExecutionRunner extends AbstractRunner<StepContextImpl> i
             isOverride = partitionPlan.getPartitionsOverride();
             numOfPartitions = partitionPlan.getPartitions();
             numOfThreads = partitionPlan.getThreads();
+            numOfThreads = (numOfThreads == 0) ? numOfPartitions : numOfThreads;
             partitionProperties = partitionPlan.getPartitionProperties();
         } else {
             numOfPartitions = plan.getPartitionsInt();


### PR DESCRIPTION
When the partition plan is defined the number of threads
are checked. If it's 0 then the number of threads is equal to the number
of partitions.
