### PR TITLE
[JBERET-140] Fix NPE if the end time is null during a JDBC update.

### DIFF
--- a/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
@@ -583,7 +583,7 @@ public final class JdbcRepository extends AbstractRepository {
         PreparedStatement preparedStatement = null;
         try {
             preparedStatement = connection.prepareStatement(update);
-            preparedStatement.setTimestamp(1, new Timestamp(stepExecution.getEndTime().getTime()));
+            preparedStatement.setTimestamp(1, createTimestamp(stepExecution.getEndTime()));
             preparedStatement.setString(2, stepExecution.getBatchStatus().name());
             preparedStatement.setString(3, stepExecution.getExitStatus());
             preparedStatement.setString(4, TableColumns.formatException(stepExecutionImpl.getException()));


### PR DESCRIPTION
This passes the TCK tests for me, but they don't fail for me without this either. @chengfang You might want to test this simple fix with your local TCK to be sure.