### PR TITLE
SPI Changes

### DIFF
--- a/jberet-core/src/main/java/org/jberet/creation/AbstractArtifactFactory.java
+++ b/jberet-core/src/main/java/org/jberet/creation/AbstractArtifactFactory.java
@@ -16,6 +16,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -133,7 +134,7 @@ public abstract class AbstractArtifactFactory implements ArtifactFactory {
         }
         for(final Method m : lifecycleMethods) {
             if (WildFlySecurityManager.isChecking()) {
-                WildFlySecurityManager.doUnchecked(new InvokeMethodPrivilegedExceptionAction(m, obj));
+                AccessController.doPrivileged(new InvokeMethodPrivilegedExceptionAction(m, obj));
             } else {
                 if (!m.isAccessible()) {
                     m.setAccessible(true);
@@ -145,7 +146,7 @@ public abstract class AbstractArtifactFactory implements ArtifactFactory {
 
     private void doInjection(final Object obj, final Field field, final Object val) throws Exception {
         if (WildFlySecurityManager.isChecking()) {
-            WildFlySecurityManager.doUnchecked(new SetFieldPrivilegedExceptionAction(field, obj, val));
+            AccessController.doPrivileged(new SetFieldPrivilegedExceptionAction(field, obj, val));
         } else {
             if (!field.isAccessible()) {
                 field.setAccessible(true);

--- a/jberet-core/src/main/java/org/jberet/creation/BatchBeanProducer.java
+++ b/jberet-core/src/main/java/org/jberet/creation/BatchBeanProducer.java
@@ -20,6 +20,7 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.URI;
 import java.net.URL;
+import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
 import java.util.Date;
 import java.util.List;
@@ -393,7 +394,7 @@ public class BatchBeanProducer {
                 final Object fieldVal;
 
                 if (WildFlySecurityManager.isChecking()) {
-                    fieldVal = WildFlySecurityManager.doUnchecked(new PrivilegedExceptionAction<Object>() {
+                    fieldVal = AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
                         @Override
                         public Object run() throws Exception {
                             if (!field.isAccessible()) {

--- a/jberet-core/src/main/java/org/jberet/job/model/FlowMerger.java
+++ b/jberet-core/src/main/java/org/jberet/job/model/FlowMerger.java
@@ -12,6 +12,7 @@
 
 package org.jberet.job.model;
 
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
 import javax.batch.operations.JobStartException;
@@ -60,7 +61,7 @@ public final class FlowMerger extends AbstractMerger<Flow> {
         }
         child.jobElements.clear();
         if (WildFlySecurityManager.isChecking()) {
-            child.jobElements = WildFlySecurityManager.doUnchecked(new PrivilegedAction<List<JobElement>>() {
+            child.jobElements = AccessController.doPrivileged(new PrivilegedAction<List<JobElement>>() {
                 @Override
                 public List<JobElement> run() {
                     return BatchUtil.clone(parent.jobElements);

--- a/jberet-core/src/main/java/org/jberet/operations/JobOperatorImpl.java
+++ b/jberet-core/src/main/java/org/jberet/operations/JobOperatorImpl.java
@@ -12,6 +12,7 @@
 
 package org.jberet.operations;
 
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -77,7 +78,7 @@ public class JobOperatorImpl implements JobOperator {
     public JobOperatorImpl() throws BatchRuntimeException {
         final BatchEnvironment batchEnvironment;
         if (WildFlySecurityManager.isChecking()) {
-            batchEnvironment = WildFlySecurityManager.doUnchecked(loaderAction);
+            batchEnvironment = AccessController.doPrivileged(loaderAction);
         } else {
             batchEnvironment = loaderAction.run();
         }

--- a/jberet-core/src/main/java/org/jberet/repository/AbstractRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/AbstractRepository.java
@@ -13,6 +13,7 @@
 package org.jberet.repository;
 
 import java.io.Serializable;
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -291,7 +292,7 @@ public abstract class AbstractRepository implements JobRepository {
 
     private static <T extends Serializable> T clone(final T object) {
         if (WildFlySecurityManager.isChecking()) {
-            return WildFlySecurityManager.doUnchecked(new PrivilegedAction<T>() {
+            return AccessController.doPrivileged(new PrivilegedAction<T>() {
                 @Override
                 public T run() {
                     return BatchUtil.clone(object);

--- a/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
@@ -14,6 +14,7 @@ package org.jberet.repository;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -985,7 +986,7 @@ public final class JdbcRepository extends AbstractRepository {
 
     private static ClassLoader getClassLoader() {
         if (WildFlySecurityManager.isChecking()) {
-            return WildFlySecurityManager.doUnchecked(new PrivilegedAction<ClassLoader>() {
+            return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
                 @Override
                 public ClassLoader run() {
                     return JdbcRepository.class.getClassLoader();

--- a/jberet-core/src/main/java/org/jberet/runtime/JobExecutionImpl.java
+++ b/jberet-core/src/main/java/org/jberet/runtime/JobExecutionImpl.java
@@ -12,6 +12,7 @@
 
 package org.jberet.runtime;
 
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Date;
@@ -61,7 +62,7 @@ public final class JobExecutionImpl extends AbstractExecution implements JobExec
         this.jobInstance = jobInstance;
         this.jobParameters = jobParameters;
         if (WildFlySecurityManager.isChecking()) {
-            this.substitutedJob = WildFlySecurityManager.doUnchecked(new PrivilegedAction<Job>() {
+            this.substitutedJob = AccessController.doPrivileged(new PrivilegedAction<Job>() {
                 @Override
                 public Job run() {
                     return BatchUtil.clone(jobInstance.unsubstitutedJob);

--- a/jberet-core/src/main/java/org/jberet/runtime/context/StepContextImpl.java
+++ b/jberet-core/src/main/java/org/jberet/runtime/context/StepContextImpl.java
@@ -13,6 +13,7 @@
 package org.jberet.runtime.context;
 
 import java.io.Serializable;
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Properties;
 import javax.batch.runtime.BatchStatus;
@@ -86,7 +87,7 @@ public class StepContextImpl extends AbstractContext implements StepContext, Clo
                 c.outerContexts[i] = outerContexts[i];
             }
             if (WildFlySecurityManager.isChecking()) {
-                c.step = WildFlySecurityManager.doUnchecked(new PrivilegedAction<Step>() {
+                c.step = AccessController.doPrivileged(new PrivilegedAction<Step>() {
                     @Override
                     public Step run() {
                         return BatchUtil.clone(step);

--- a/jberet-core/src/main/java/org/jberet/spi/BatchEnvironment.java
+++ b/jberet-core/src/main/java/org/jberet/spi/BatchEnvironment.java
@@ -12,8 +12,6 @@
 package org.jberet.spi;
 
 import java.util.Properties;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
 import javax.transaction.TransactionManager;
 
 import org.jberet.repository.JobRepository;
@@ -38,45 +36,11 @@ public interface BatchEnvironment {
     ArtifactFactory getArtifactFactory();
 
     /**
-     * Submits a {@link Runnable runnable} task for execution and returns a {@link java.util.concurrent.Future future} representing that
-     * task. The futures {@link java.util.concurrent.Future#get() geth} method will return {@code null} upon successful
-     * completion.
+     * Submits a {@link Runnable runnable} task for execution.
      *
      * @param task the task to submit
-     *
-     * @return a future representing pending completion of the task
-     *
-     * @see java.util.concurrent.ExecutorService#submit(Runnable)
      */
-    Future<?> submitTask(Runnable task);
-
-    /**
-     * Submits a {@link Runnable runnable} task for execution and returns a {@link Future future} representing that
-     * task. The {@link Future future's} get method will return the given result upon successful completion.
-     *
-     * @param task   the task to submit
-     * @param result the result to return
-     * @param <T>    the type of the result
-     *
-     * @return a {@link Future future} representing pending completion of the task
-     *
-     * @see java.util.concurrent.ExecutorService#submit(Runnable, Object)
-     */
-    <T> Future<T> submitTask(Runnable task, T result);
-
-    /**
-     * Submits a value-returning task for execution and returns a {@link Future future} representing the pending
-     * results of the task. The {@link Future future's} get method will return the task's result upon successful
-     * completion.
-     *
-     * @param task the task to submit
-     * @param <T>  the type of the result
-     *
-     * @return a {@link Future future} representing pending completion of the task
-     *
-     * @see java.util.concurrent.ExecutorService#submit(java.util.concurrent.Callable)
-     */
-    <T> Future<T> submitTask(Callable<T> task);
+    void submitTask(Runnable task);
 
     /**
      * Returns a transaction manager to be used for executions that require a transaction.

--- a/jberet-core/src/main/java/org/jberet/util/BatchUtil.java
+++ b/jberet-core/src/main/java/org/jberet/util/BatchUtil.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -37,13 +38,13 @@ public final class BatchUtil {
 
 
     static {
-        clonerFactory = WildFlySecurityManager.doUnchecked(new PrivilegedAction<ObjectClonerFactory>() {
+        clonerFactory = AccessController.doPrivileged(new PrivilegedAction<ObjectClonerFactory>() {
             @Override
             public ObjectClonerFactory run() {
                 return ObjectCloners.getSerializingObjectClonerFactory();
             }
         });
-        cloner = WildFlySecurityManager.doUnchecked(new PrivilegedAction<ObjectCloner>() {
+        cloner = AccessController.doPrivileged(new PrivilegedAction<ObjectCloner>() {
             @Override
             public ObjectCloner run() {
                 return clonerFactory.createCloner(new ClonerConfiguration());

--- a/jberet-core/src/test/java/org/jberet/test/JobRepositoryTest.java
+++ b/jberet-core/src/test/java/org/jberet/test/JobRepositoryTest.java
@@ -91,18 +91,8 @@ public class JobRepositoryTest {
             }
 
             @Override
-            public Future<?> submitTask(final Runnable task) {
-                return null;
-            }
+            public void submitTask(final Runnable task) {
 
-            @Override
-            public <T> Future<T> submitTask(final Runnable task, final T result) {
-                return null;
-            }
-
-            @Override
-            public <T> Future<T> submitTask(final Callable<T> task) {
-                return null;
             }
 
             @Override

--- a/jberet-se/src/main/java/org/jberet/se/BatchSEEnvironment.java
+++ b/jberet-se/src/main/java/org/jberet/se/BatchSEEnvironment.java
@@ -115,18 +115,8 @@ public final class BatchSEEnvironment implements BatchEnvironment {
     }
 
     @Override
-    public Future<?> submitTask(final Runnable task) {
-        return executorService.submit(task);
-    }
-
-    @Override
-    public <T> Future<T> submitTask(final Runnable task, final T result) {
-        return executorService.submit(task, result);
-    }
-
-    @Override
-    public <T> Future<T> submitTask(final Callable<T> task) {
-        return executorService.submit(task);
+    public void submitTask(final Runnable task) {
+        executorService.submit(task);
     }
 
     @Override


### PR DESCRIPTION
The first commit just removes the requirement for the `doUnchecked` permission to execute privileged blocks.

The second commit could be a bit more debatable. I removed the 2 of the `submitTask()` methods as they aren't used anywhere. I also changed the remaining method to have a void return type. The value is not used anywhere. We also made a breaking change to the `BatchEnvironment` by adding a new method, `JobXmlResolver getJobXmlResolver()`. So now seems like the right time to make this change.