### PR TITLE
PartitionAnalyzer optional transactions

### DIFF
--- a/jberet-core/src/main/java/org/jberet/runtime/runner/StepExecutionRunner.java
+++ b/jberet-core/src/main/java/org/jberet/runtime/runner/StepExecutionRunner.java
@@ -83,7 +83,7 @@ public final class StepExecutionRunner extends AbstractRunner<StepContextImpl> i
     final TransactionManager tm;
     final StepExecutionImpl stepExecution;
 
-    private boolean analyzerTxEnabled;
+    private boolean analyzerTxEnabled = true;
 
     public StepExecutionRunner(final StepContextImpl stepContext, final CompositeExecutionRunner enclosingRunner) {
         super(stepContext, enclosingRunner);

--- a/jberet-core/src/main/java/org/jberet/runtime/runner/StepExecutionRunner.java
+++ b/jberet-core/src/main/java/org/jberet/runtime/runner/StepExecutionRunner.java
@@ -83,6 +83,8 @@ public final class StepExecutionRunner extends AbstractRunner<StepContextImpl> i
     final TransactionManager tm;
     final StepExecutionImpl stepExecution;
 
+    private boolean analyzerTxEnabled;
+
     public StepExecutionRunner(final StepContextImpl stepContext, final CompositeExecutionRunner enclosingRunner) {
         super(stepContext, enclosingRunner);
         this.step = stepContext.getStep();
@@ -93,6 +95,11 @@ public final class StepExecutionRunner extends AbstractRunner<StepContextImpl> i
         } else {
             tm = jobContext.getBatchEnvironment().getTransactionManager();
         }
+
+        if (step.getProperties() != null) {
+            analyzerTxEnabled = !Boolean.parseBoolean(step.getProperties().get(PropertyKey.ANALYZER_TX_DISABLED));
+        }
+
         createStepListeners();
         initPartitionConfig();
     }
@@ -342,7 +349,7 @@ public final class StepExecutionRunner extends AbstractRunner<StepContextImpl> i
         BatchStatus consolidatedBatchStatus = BatchStatus.STARTED;
         final List<PartitionExecutionImpl> fromAllPartitions = new ArrayList<PartitionExecutionImpl>();
 
-        if (analyzer != null) {
+        if (analyzer != null && analyzerTxEnabled) {
             tm.begin();
         }
         try {
@@ -377,14 +384,14 @@ public final class StepExecutionRunner extends AbstractRunner<StepContextImpl> i
                 }
             }
 
-            if (analyzer != null &&
+            if (analyzer != null && analyzerTxEnabled &&
                     (consolidatedBatchStatus == BatchStatus.FAILED || consolidatedBatchStatus == BatchStatus.STOPPED)) {
                 tm.rollback();
             } else {
                 if (reducer != null) {
                     reducer.beforePartitionedStepCompletion();
                 }
-                if (analyzer != null) {
+                if (analyzer != null && analyzerTxEnabled) {
                     tm.commit();
                 }
             }
@@ -400,7 +407,7 @@ public final class StepExecutionRunner extends AbstractRunner<StepContextImpl> i
             BatchLogger.LOGGER.failToRunJob(e, jobContext.getJobName(), step.getId(), step);
             consolidatedBatchStatus = BatchStatus.FAILED;
 
-            if (analyzer != null) {
+            if (analyzer != null && analyzerTxEnabled) {
                 try {
                     tm.rollback();
                 } catch (final Exception ee) {

--- a/jberet-core/src/main/java/org/jberet/spi/PropertyKey.java
+++ b/jberet-core/src/main/java/org/jberet/spi/PropertyKey.java
@@ -9,8 +9,6 @@
 
 package org.jberet.spi;
 
-import javax.batch.api.partition.PartitionAnalyzer;
-
 /**
  * Keys used for JBeret specific configuration and job properties.
  *

--- a/jberet-core/src/main/java/org/jberet/spi/PropertyKey.java
+++ b/jberet-core/src/main/java/org/jberet/spi/PropertyKey.java
@@ -9,6 +9,8 @@
 
 package org.jberet.spi;
 
+import javax.batch.api.partition.PartitionAnalyzer;
+
 /**
  * Keys used for JBeret specific configuration and job properties.
  *
@@ -59,5 +61,12 @@ public interface PropertyKey {
     String RESTART_MODE_STRICT = "strict";
     String RESTART_MODE_FORCE = "force";
     String RESTART_MODE_DETECT = "detect";
+
+    /**
+     * A key used to disable transactions around calls to {@link PartitionAnalyzer}.
+     * Transactions around calls to {@link PartitionAnalyzer} might time out in long running steps which can
+     * be prevented by disabling the transaction using this property.
+     */
+    String ANALYZER_TX_DISABLED = "jberet.analyzer.txDisabled";
 
 }

--- a/test-apps/chunkPartition/src/main/resources/META-INF/batch-jobs/org.jberet.test.chunkPartition.xml
+++ b/test-apps/chunkPartition/src/main/resources/META-INF/batch-jobs/org.jberet.test.chunkPartition.xml
@@ -15,6 +15,9 @@
 <job id="org.jberet.test.chunkPartition" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
     <step id="org.jberet.test.chunkPartition.step1"
           parent="org.jberet.test.chunkPartition.step0" jsl-name="org.jberet.test.chunkPartitionFailComplete">
+        <properties>
+			<property name="org.jberet.transaction.analyzerTxDisabled" value="true"/>
+		</properties>
         <partition>
             <plan partitions="10" threads="#{jobParameters['thread.count']}">
                 <properties partition="0">

--- a/test-apps/chunkPartition/src/main/resources/META-INF/batch-jobs/org.jberet.test.chunkPartition.xml
+++ b/test-apps/chunkPartition/src/main/resources/META-INF/batch-jobs/org.jberet.test.chunkPartition.xml
@@ -15,6 +15,9 @@
 <job id="org.jberet.test.chunkPartition" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
     <step id="org.jberet.test.chunkPartition.step1"
           parent="org.jberet.test.chunkPartition.step0" jsl-name="org.jberet.test.chunkPartitionFailComplete">
+        <properties>
+            <property name="jberet.analyzer.txDisabled" value="true"/>
+        </properties>
         <partition>
             <plan partitions="10" threads="#{jobParameters['thread.count']}">
                 <properties partition="0">

--- a/test-apps/chunkPartition/src/main/resources/META-INF/batch-jobs/org.jberet.test.chunkPartition.xml
+++ b/test-apps/chunkPartition/src/main/resources/META-INF/batch-jobs/org.jberet.test.chunkPartition.xml
@@ -15,9 +15,6 @@
 <job id="org.jberet.test.chunkPartition" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
     <step id="org.jberet.test.chunkPartition.step1"
           parent="org.jberet.test.chunkPartition.step0" jsl-name="org.jberet.test.chunkPartitionFailComplete">
-        <properties>
-			<property name="org.jberet.transaction.analyzerTxDisabled" value="true"/>
-		</properties>
         <partition>
             <plan partitions="10" threads="#{jobParameters['thread.count']}">
                 <properties partition="0">


### PR DESCRIPTION
This pull request adds support for a step property `org.jberet.transaction.analyzerTxDisabled` that disables transactions for PartitionAnalyzer calls when set to true.