### PR TITLE
Updates JBeret's free Miredot license to an open-source license.

### DIFF
--- a/jberet-rest-api/pom.xml
+++ b/jberet-rest-api/pom.xml
@@ -59,7 +59,7 @@
                 </executions>
                 <configuration>
                     <license>
-                        UHJvamVjdHxvcmcuamJlcmV0LmpiZXJldC1yZXN0LWFwaXwyMDE2LTEwLTA3fHRydWUjTUMwQ0ZRQ1RjbTd2R2xJSmNnWG1YYllGYlZ5RGIraHhFd0lVQXFibXdUcUNpODFUK29SdW9xOXpvcUw4ZkVjPQ==
+                        cHJvamVjdHxvcmcuamJlcmV0LmpiZXJldC1yZXN0LWFwaXwyMDE4LTAyLTE2fHRydWV8LTEjTUMwQ0ZBR1dJc0ZtZGlFc3J3OGhlQXdFRXBmTkJPVkNBaFVBaFE2ekVZM2pLdm9YSkFjM2VQYjNCQ2xNaVh3PQ==
                     </license>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Dear maintainers of JBeret,

We noticed you are currently using a free Miredot license for your open-source project. We thought we'd help you out and upgrade that license to an open-source license.

With this license you get access to all the paying features, free of charge. If you have any questions, problems or feedback, please let us know!

Kind Regards,

Ewout & The Miredot team.