### PR TITLE
NullPointerException when using artifacts with default-package.

### DIFF
--- a/jberet-core/src/test/java/NoPackageBatchlet.java
+++ b/jberet-core/src/test/java/NoPackageBatchlet.java
@@ -1,0 +1,8 @@
+import javax.batch.api.AbstractBatchlet;
+
+public class NoPackageBatchlet extends AbstractBatchlet {
+    @Override
+    public String process() throws Exception {
+        return null;
+    }
+}

--- a/jberet-core/src/test/java/org/jberet/creation/AbstractArtifactFactoryTest.java
+++ b/jberet-core/src/test/java/org/jberet/creation/AbstractArtifactFactoryTest.java
@@ -1,0 +1,38 @@
+package org.jberet.creation;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractArtifactFactoryTest {
+
+    private AbstractArtifactFactory factory = new AbstractArtifactFactory() {
+        @Override
+        public Object create(String ref, Class<?> cls, ClassLoader classLoader) throws Exception {
+            return null;
+        }
+
+        @Override
+        public Class<?> getArtifactClass(String ref, ClassLoader classLoader) {
+            return null;
+        }
+    };
+
+    private Class noPackageBatchletClass;
+    private Object noPackageBatchlet;
+
+    @Before
+    public void setup() throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        noPackageBatchletClass = Class.forName("NoPackageBatchlet");
+        noPackageBatchlet = noPackageBatchletClass.newInstance();
+    }
+
+    @Test
+    public void testDestroyShouldNotFailForDefaultPackage()  {
+        factory.destroy(noPackageBatchlet);
+    }
+
+    @Test
+    public void testDoInjectionShouldNotFailForDefaultPackage() throws Exception {
+        factory.doInjection(noPackageBatchlet, noPackageBatchletClass, null, null, null, null);
+    }
+}


### PR DESCRIPTION
During a Java EE course, I received the following error message:

```
15:58:43,965 WARN  [org.jberet] (Batch Thread - 2) JBERET000013: Failed to destroy artifact ReadBatchlet@2b167183: java.lang.NullPointerException
	at org.jberet.creation.AbstractArtifactFactory.invokeAnnotatedLifecycleMethod(AbstractArtifactFactory.java:99)
	at org.jberet.creation.AbstractArtifactFactory.destroy(AbstractArtifactFactory.java:44)
	at org.jberet.runtime.context.JobContextImpl.destroyArtifact(JobContextImpl.java:205)
	at org.jberet.runtime.runner.BatchletRunner.run(BatchletRunner.java:115)
	at org.jberet.runtime.runner.StepExecutionRunner.runBatchletOrChunk(StepExecutionRunner.java:222)
	at org.jberet.runtime.runner.StepExecutionRunner.run(StepExecutionRunner.java:140)
	at org.jberet.runtime.runner.CompositeExecutionRunner.runStep(CompositeExecutionRunner.java:164)
	at org.jberet.runtime.runner.CompositeExecutionRunner.runFromHeadOrRestartPoint(CompositeExecutionRunner.java:88)
	at org.jberet.runtime.runner.JobExecutionRunner.run(JobExecutionRunner.java:59)
	at org.wildfly.extension.batch.jberet.impl.BatchEnvironmentService$WildFlyBatchEnvironment$1.run(BatchEnvironmentService.java:243)
	at org.wildfly.extension.requestcontroller.RequestController$QueuedTask$1.run(RequestController.java:497)
	at org.jberet.spi.JobExecutor$3.run(JobExecutor.java:161)
	at org.jberet.spi.JobExecutor$1.run(JobExecutor.java:99)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
	at org.jboss.threads.JBossThread.run(JBossThread.java:320)
```

Looking at the source code, it seemed the problem was caused by the fact the my Batchlet was in the default package.

Although in practice this is a situation that will probably never occur, I still think it should not result in NullPointerExceptions.

This pull request should fix the errors. 

Please note that this does change the behaviour of a job: runtime exceptions in the `destroy` method of the `AbstractArtifactFactory` cause the job to be `FAILED` instead of `COMPLETED`.