### PR TITLE
UT update

### DIFF
--- a/wildfly-jberet-samples/restReader/src/test/java/org/jberet/samples/wildfly/restreader/RestReaderIT.java
+++ b/wildfly-jberet-samples/restReader/src/test/java/org/jberet/samples/wildfly/restreader/RestReaderIT.java
@@ -112,7 +112,6 @@ public final class RestReaderIT extends BatchTestBase {
         jobParams.setProperty("restUrl", restUrl + "/movies/error");
         final JobExecutionEntity jobExecutionEntity =
                 startJobCheckStatus(jobName, jobParams, 5000, BatchStatus.FAILED);
-        //Assert.assertEquals("HTTP 500 Internal Server Error", jobExecutionEntity.getExitStatus());
         Assert.assertThat(jobExecutionEntity.getExitStatus(), containsString("HTTP 500 Internal Server Error"));
     }
 }

--- a/wildfly-jberet-samples/restReader/src/test/java/org/jberet/samples/wildfly/restreader/RestReaderIT.java
+++ b/wildfly-jberet-samples/restReader/src/test/java/org/jberet/samples/wildfly/restreader/RestReaderIT.java
@@ -21,6 +21,8 @@ import org.jberet.samples.wildfly.common.BatchTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 /**
  * Tests for {@link org.jberet.support.io.RestItemReader}, which reads data
  * by calling REST GET operations on the configured collection resource
@@ -110,6 +112,7 @@ public final class RestReaderIT extends BatchTestBase {
         jobParams.setProperty("restUrl", restUrl + "/movies/error");
         final JobExecutionEntity jobExecutionEntity =
                 startJobCheckStatus(jobName, jobParams, 5000, BatchStatus.FAILED);
-        Assert.assertEquals("HTTP 500 Internal Server Error", jobExecutionEntity.getExitStatus());
+        //Assert.assertEquals("HTTP 500 Internal Server Error", jobExecutionEntity.getExitStatus());
+        Assert.assertThat(jobExecutionEntity.getExitStatus(), containsString("HTTP 500 Internal Server Error"));
     }
 }


### PR DESCRIPTION
The testError UT failed against Wildfly 10.1.0 as the error string returned did
not match what was expected;

org.junit.ComparisonFailure: expected:<[]HTTP 500 Internal Se...> but
was:<[JBERET000652: Failed to serialize:
javax.ws.rs.InternalServerErrorException: ]HTTP 500 Internal Se...>

Changed the test to look for an instance of "HTTP 500 Internal Server
Error" in the returned string.