### PR TITLE
[JBERET-286] Abstract the JobOperatorImpl so it can be extended by im…

### DIFF
--- a/jberet-core/src/main/java/org/jberet/_private/BatchMessages.java
+++ b/jberet-core/src/main/java/org/jberet/_private/BatchMessages.java
@@ -195,5 +195,6 @@ public interface BatchMessages {
     @Message(id = 653, value = "Failed to deserialize: %s")
     BatchRuntimeException failedToDeserialize(@Cause Throwable cause, Serializable value);
 
-
+    @Message(id = 655, value = "ClassLoader (%s) is already registered to a job operator context")
+    IllegalArgumentException classLoaderAlreadyRegistered(ClassLoader classLoader);
 }

--- a/jberet-core/src/main/java/org/jberet/operations/AbstractJobOperator.java
+++ b/jberet-core/src/main/java/org/jberet/operations/AbstractJobOperator.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.operations;
+
+import static org.jberet._private.BatchMessages.MESSAGES;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import javax.batch.operations.JobExecutionAlreadyCompleteException;
+import javax.batch.operations.JobExecutionIsRunningException;
+import javax.batch.operations.JobExecutionNotMostRecentException;
+import javax.batch.operations.JobExecutionNotRunningException;
+import javax.batch.operations.JobOperator;
+import javax.batch.operations.JobRestartException;
+import javax.batch.operations.JobSecurityException;
+import javax.batch.operations.JobStartException;
+import javax.batch.operations.NoSuchJobException;
+import javax.batch.operations.NoSuchJobExecutionException;
+import javax.batch.operations.NoSuchJobInstanceException;
+import javax.batch.runtime.BatchStatus;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.JobInstance;
+import javax.batch.runtime.StepExecution;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.InvalidTransactionException;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+import org.jberet._private.BatchLogger;
+import org.jberet.creation.ArchiveXmlLoader;
+import org.jberet.creation.ArtifactFactoryWrapper;
+import org.jberet.job.model.Job;
+import org.jberet.repository.ApplicationAndJobName;
+import org.jberet.repository.JobRepository;
+import org.jberet.runtime.JobExecutionImpl;
+import org.jberet.runtime.JobInstanceImpl;
+import org.jberet.runtime.context.JobContextImpl;
+import org.jberet.runtime.runner.JobExecutionRunner;
+import org.jberet.spi.BatchEnvironment;
+import org.jberet.spi.PropertyKey;
+
+/**
+ * An abstract implementation of a {@link JobOperator}. Subclasses should generally delegate to the super methods of
+ * this abstraction.
+ *
+ * @author Cheng Fang - Initial API and implementation
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+
+public abstract class AbstractJobOperator implements JobOperator {
+
+    /**
+     * Returns the batch environment that should be used for this JobOperator. Implementations should never return
+     * {@code null}.
+     *
+     * @return the batch environment
+     */
+    protected abstract BatchEnvironment getBatchEnvironment();
+
+    /**
+     * This is equivalent to {@link #getBatchEnvironment()#getJobRepository() getBatchEnvironment().getJobRepository()}.
+     *
+     * @return the job repository that belongs to the batch environment
+     */
+    protected JobRepository getJobRepository() {
+        return getBatchEnvironment().getJobRepository();
+    }
+
+    @Override
+    public long start(final String jobXMLName, final Properties jobParameters) throws JobStartException, JobSecurityException {
+        final BatchEnvironment batchEnvironment = getBatchEnvironment();
+        final Job jobDefined = ArchiveXmlLoader.loadJobXml(jobXMLName, batchEnvironment.getClassLoader(),
+                new ArrayList<Job>(), batchEnvironment.getJobXmlResolver());
+        return start(jobDefined, jobParameters);
+    }
+
+    /**
+     * Starts a pre-configured {@link Job} instance, with job parameters.
+     *
+     * @param jobDefined    a pre-configured job
+     * @param jobParameters job parameters for the current job execution
+     *
+     * @return job execution id as a long number
+     *
+     * @throws JobStartException    if failed to start the job
+     * @throws JobSecurityException if failed to start the job due to security permission
+     * @see org.jberet.job.model.JobBuilder
+     * @since 1.2.0
+     */
+    public long start(final Job jobDefined, final Properties jobParameters) throws JobStartException, JobSecurityException {
+        final BatchEnvironment batchEnvironment = getBatchEnvironment();
+        final ClassLoader classLoader = batchEnvironment.getClassLoader();
+        final String applicationName = getApplicationName();
+        getJobRepository().addJob(new ApplicationAndJobName(applicationName, jobDefined.getId()), jobDefined);
+        try {
+            return invokeTransaction(new TransactionInvocation<Long>() {
+                @Override
+                public Long invoke() throws JobStartException, JobSecurityException {
+                    final JobInstanceImpl jobInstance = getJobRepository().createJobInstance(jobDefined, applicationName, classLoader);
+                    return startJobExecution(jobInstance, jobParameters, null);
+                }
+            });
+        } catch (InvalidTransactionException e) {
+            throw new JobStartException(e);
+        } catch (SystemException e) {
+            throw new JobStartException(e);
+        }
+    }
+
+    @Override
+    public void stop(final long executionId) throws NoSuchJobExecutionException,
+            JobExecutionNotRunningException, JobSecurityException {
+        final JobExecutionImpl jobExecution = getJobExecutionImpl(executionId);
+        final BatchStatus s = jobExecution.getBatchStatus();
+        if (s == BatchStatus.STOPPED || s == BatchStatus.FAILED || s == BatchStatus.ABANDONED ||
+                s == BatchStatus.COMPLETED) {
+            throw MESSAGES.jobExecutionNotRunningException(executionId, s);
+        } else if (s == BatchStatus.STOPPING) {
+            //in process of stopping, do nothing
+        } else {
+            jobExecution.setBatchStatus(BatchStatus.STOPPING);
+            jobExecution.stop();
+        }
+    }
+
+    @Override
+    public Set<String> getJobNames() throws JobSecurityException {
+        return getJobRepository().getJobNames();
+    }
+
+    @Override
+    public int getJobInstanceCount(final String jobName) throws NoSuchJobException, JobSecurityException {
+        if (jobName == null) {
+            throw MESSAGES.noSuchJobException(null);
+        }
+        final JobRepository repository = getJobRepository();
+        final int count = repository.getJobInstanceCount(jobName);
+        if (count == 0 && !repository.jobExists(jobName)) {
+            throw MESSAGES.noSuchJobException(jobName);
+        }
+        return count;
+    }
+
+    @Override
+    public List<JobInstance> getJobInstances(final String jobName, final int start, final int count) throws NoSuchJobException, JobSecurityException {
+        if (jobName == null) {
+            throw MESSAGES.noSuchJobException(null);
+        }
+        final JobRepository repository = getJobRepository();
+        final List<JobInstance> instances = repository.getJobInstances(jobName);
+        final int size = instances.size();
+        if (size == 0 && !repository.jobExists(jobName)) {
+            throw MESSAGES.noSuchJobException(jobName);
+        }
+        return instances.subList(Math.min(start, size), Math.min(start + count, size));
+    }
+
+    @Override
+    public List<Long> getRunningExecutions(final String jobName) throws NoSuchJobException, JobSecurityException {
+        if (jobName == null) {
+            throw MESSAGES.noSuchJobException(null);
+        }
+        final JobRepository repository = getJobRepository();
+        final List<Long> result = repository.getRunningExecutions(jobName);
+        if (result.size() == 0 && !repository.jobExists(jobName)) {
+            throw MESSAGES.noSuchJobException(jobName);
+        }
+        return result;
+    }
+
+    @Override
+    public Properties getParameters(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return getJobExecutionImpl(executionId).getJobParameters();
+    }
+
+    @Override
+    public long restart(final long executionId, final Properties restartParameters) throws JobExecutionAlreadyCompleteException,
+            NoSuchJobExecutionException, JobExecutionNotMostRecentException, JobRestartException, JobSecurityException {
+        final JobExecutionImpl originalToRestart = getJobExecutionImpl(executionId);
+
+        if (Job.UNRESTARTABLE.equals(originalToRestart.getRestartPosition())) {
+            throw MESSAGES.unrestartableJob(originalToRestart.getJobName(), executionId);
+        }
+
+        final BatchStatus previousStatus = originalToRestart.getBatchStatus();
+        if (previousStatus == BatchStatus.FAILED || previousStatus == BatchStatus.STOPPED) {
+            return restartFailedOrStopped(executionId, originalToRestart, restartParameters);
+        }
+
+        if (previousStatus == BatchStatus.COMPLETED) {
+            throw MESSAGES.jobExecutionAlreadyCompleteException(executionId);
+        }
+
+        if (previousStatus == BatchStatus.ABANDONED) {
+            throw MESSAGES.jobRestartException(executionId, previousStatus);
+        }
+
+        //previousStatus is now one of STARTING, STARTED, or STOPPING
+        final String restartMode = restartParameters != null ? restartParameters.getProperty(PropertyKey.RESTART_MODE) : null;
+        if (PropertyKey.RESTART_MODE_STRICT.equalsIgnoreCase(restartMode)) {
+            throw MESSAGES.jobRestartException(executionId, previousStatus);
+        } else if (restartMode == null || restartMode.equalsIgnoreCase(PropertyKey.RESTART_MODE_DETECT)) {
+            //to detect if originalToRestart had crashed or not
+            if (originalToRestart.getJobInstance().getUnsubstitutedJob() != null) {
+                throw MESSAGES.restartRunningExecution(executionId, originalToRestart.getJobName(), previousStatus, restartMode);
+            }
+        } else if (!restartMode.equalsIgnoreCase(PropertyKey.RESTART_MODE_FORCE)) {
+            throw MESSAGES.invalidRestartMode(executionId, originalToRestart.getJobName(), previousStatus, restartMode,
+                    Arrays.asList(PropertyKey.RESTART_MODE_DETECT, PropertyKey.RESTART_MODE_FORCE, PropertyKey.RESTART_MODE_STRICT));
+        }
+
+        //update batch status in originalToRestart to FAILED, for previousStatus STARTING, STARTED, or STOPPING
+        BatchLogger.LOGGER.markAsFailed(executionId, originalToRestart.getJobName(), previousStatus, restartMode);
+        originalToRestart.setBatchStatus(BatchStatus.FAILED);
+        getJobRepository().updateJobExecution(originalToRestart, false, false);
+        return restartFailedOrStopped(executionId, originalToRestart, restartParameters);
+    }
+
+    @Override
+    public void abandon(final long executionId) throws
+            NoSuchJobExecutionException, JobExecutionIsRunningException, JobSecurityException {
+        final JobExecutionImpl jobExecution = getJobExecutionImpl(executionId);
+        final BatchStatus batchStatus = jobExecution.getBatchStatus();
+        if (batchStatus == BatchStatus.COMPLETED ||
+                batchStatus == BatchStatus.FAILED ||
+                batchStatus == BatchStatus.STOPPED ||
+                batchStatus == BatchStatus.ABANDONED) {
+            jobExecution.setBatchStatus(BatchStatus.ABANDONED);
+            getJobRepository().updateJobExecution(jobExecution, false, false);
+
+            final JobInstanceImpl jobInstance = jobExecution.getJobInstance();
+            if (jobInstance != null) {
+                jobInstance.setUnsubstitutedJob(null);
+            }
+        } else {
+            throw MESSAGES.jobExecutionIsRunningException(executionId);
+        }
+    }
+
+    @Override
+    public JobInstance getJobInstance(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        final JobExecutionImpl jobExecution = getJobExecutionImpl(executionId);
+        return jobExecution.getJobInstance();
+    }
+
+    @Override
+    public List<JobExecution> getJobExecutions(final JobInstance instance) throws
+            NoSuchJobInstanceException, JobSecurityException {
+        if (instance == null) {
+            throw MESSAGES.noSuchJobInstance(null);
+        }
+        return getJobRepository().getJobExecutions(instance);
+    }
+
+    @Override
+    public JobExecution getJobExecution(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return getJobExecutionImpl(executionId);
+    }
+
+    @Override
+    public List<StepExecution> getStepExecutions(final long jobExecutionId) throws
+            NoSuchJobExecutionException, JobSecurityException {
+        final List<StepExecution> stepExecutions = getJobRepository().getStepExecutions(jobExecutionId, getBatchEnvironment().getClassLoader());
+        if (stepExecutions.isEmpty()) {
+            //check if the jobExecutionId passed in points to a valid JobExecution
+            //since no step executions under this jobExecutionId was found, it's likely this job execution may not exist
+            //getJobExecutionImpl() call will throw NoSuchJobExecutionException for non-exist jobExecutionId.
+            getJobExecutionImpl(jobExecutionId);
+        }
+        return stepExecutions;
+    }
+
+    /**
+     * Returns the job execution implementation found in the job repository.
+     *
+     * @param executionId the execution id
+     *
+     * @return the job execution implementation
+     *
+     * @throws NoSuchJobExecutionException if the job was not found in the repository
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected JobExecutionImpl getJobExecutionImpl(final long executionId) throws NoSuchJobExecutionException {
+        final JobExecutionImpl jobExecution = (JobExecutionImpl) getJobRepository().getJobExecution(executionId);
+        if (jobExecution == null) {
+            throw MESSAGES.noSuchJobExecution(executionId);
+        }
+        return jobExecution;
+    }
+
+    /**
+     * Restarts a FAILED or STOPPED job execution.
+     *
+     * @param executionId       the old job execution id to restart
+     * @param originalToRestart the old job execution
+     * @param restartParameters restart job parameters
+     *
+     * @return the new job execution id
+     *
+     * @throws JobExecutionNotMostRecentException
+     * @throws JobRestartException
+     */
+    private long restartFailedOrStopped(final long executionId, final JobExecutionImpl originalToRestart, final Properties restartParameters)
+            throws JobExecutionNotMostRecentException, JobRestartException {
+        final JobInstanceImpl jobInstance = originalToRestart.getJobInstance();
+        final List<JobExecution> executions = getJobExecutions(jobInstance);
+        final JobExecution mostRecentExecution = executions.get(executions.size() - 1);
+        if (executionId != mostRecentExecution.getExecutionId()) {
+            throw MESSAGES.jobExecutionNotMostRecentException(executionId, jobInstance.getInstanceId());
+        }
+        final BatchEnvironment batchEnvironment = getBatchEnvironment();
+        final JobRepository repository = getJobRepository();
+
+        // the job may not have been loaded, e.g., when the restart is performed in a new JVM
+        final String jobName = originalToRestart.getJobName();
+        Properties oldJobParameters = originalToRestart.getJobParameters();
+        Job jobDefined = jobInstance.getUnsubstitutedJob();
+        if (jobDefined == null) {
+            final ApplicationAndJobName applicationAndJobName = new ApplicationAndJobName(jobInstance.getApplicationName(), jobName);
+            jobDefined = repository.getJob(applicationAndJobName);
+
+            if (jobDefined == null) {
+                String jobXmlName = null;
+                if (oldJobParameters != null) {
+                    jobXmlName = oldJobParameters.getProperty(Job.JOB_XML_NAME);
+                }
+                if (jobXmlName == null) {
+                    jobXmlName = jobName;
+                } else {
+                    oldJobParameters.remove(Job.JOB_XML_NAME);
+                    if (!oldJobParameters.propertyNames().hasMoreElements()) {
+                        oldJobParameters = null;
+                    }
+                }
+                jobDefined = ArchiveXmlLoader.loadJobXml(jobXmlName, batchEnvironment.getClassLoader(), new ArrayList<Job>(), batchEnvironment.getJobXmlResolver());
+                repository.addJob(applicationAndJobName, jobDefined);
+            }
+            jobInstance.setUnsubstitutedJob(jobDefined);
+        }
+
+        try {
+            final Properties combinedProperties;
+            if (oldJobParameters != null) {
+                if (restartParameters == null) {
+                    combinedProperties = oldJobParameters;
+                } else {
+                    combinedProperties = new Properties(oldJobParameters);
+                    for (final String k : restartParameters.stringPropertyNames()) {
+                        combinedProperties.setProperty(k, restartParameters.getProperty(k));
+                    }
+                }
+            } else {
+                combinedProperties = restartParameters;
+            }
+
+            return invokeTransaction(new TransactionInvocation<Long>() {
+                @Override
+                public Long invoke() throws JobStartException, JobSecurityException {
+                    return startJobExecution(jobInstance, combinedProperties, originalToRestart);
+                }
+            });
+        } catch (final Exception e) {
+            throw new JobRestartException(e);
+        }
+    }
+
+    private long startJobExecution(final JobInstanceImpl jobInstance, final Properties jobParameters, final JobExecutionImpl originalToRestart) throws JobStartException, JobSecurityException {
+        final BatchEnvironment batchEnvironment = getBatchEnvironment();
+        final JobRepository repository = getJobRepository();
+        final JobExecutionImpl jobExecution = repository.createJobExecution(jobInstance, jobParameters);
+        final JobContextImpl jobContext = new JobContextImpl(jobExecution, originalToRestart, new ArtifactFactoryWrapper(batchEnvironment.getArtifactFactory()), repository, batchEnvironment);
+
+        final JobExecutionRunner jobExecutionRunner = new JobExecutionRunner(jobContext);
+        jobContext.getBatchEnvironment().submitTask(jobExecutionRunner);
+        return jobExecution.getExecutionId();
+    }
+
+    private String getApplicationName() {
+        try {
+            return InitialContext.doLookup("java:app/AppName");
+        } catch (NamingException e) {
+            return null;
+        }
+    }
+
+    private <T> T invokeTransaction(final TransactionInvocation<T> transactionInvocation) throws SystemException, InvalidTransactionException {
+        final TransactionManager tm = getBatchEnvironment().getTransactionManager();
+        final Transaction tx = tm.suspend();
+        if (tx != null) {
+            try {
+                return transactionInvocation.invoke();
+            } finally {
+                tm.resume(tx);
+            }
+        }
+        // No transaction in process
+        return transactionInvocation.invoke();
+    }
+
+    private interface TransactionInvocation<T> {
+
+        T invoke() throws JobStartException, JobSecurityException;
+    }
+}

--- a/jberet-core/src/main/java/org/jberet/operations/DelegatingJobOperator.java
+++ b/jberet-core/src/main/java/org/jberet/operations/DelegatingJobOperator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.operations;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import javax.batch.operations.JobExecutionAlreadyCompleteException;
+import javax.batch.operations.JobExecutionIsRunningException;
+import javax.batch.operations.JobExecutionNotMostRecentException;
+import javax.batch.operations.JobExecutionNotRunningException;
+import javax.batch.operations.JobOperator;
+import javax.batch.operations.JobRestartException;
+import javax.batch.operations.JobSecurityException;
+import javax.batch.operations.JobStartException;
+import javax.batch.operations.NoSuchJobException;
+import javax.batch.operations.NoSuchJobExecutionException;
+import javax.batch.operations.NoSuchJobInstanceException;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.JobInstance;
+import javax.batch.runtime.StepExecution;
+
+import org.jberet.spi.JobOperatorContext;
+
+/**
+ * A delegating job operator. By default the delegate is retrieved from the
+ * {@linkplain JobOperatorContext#getJobOperator() context}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DelegatingJobOperator implements JobOperator {
+
+    @Override
+    public Set<String> getJobNames() throws JobSecurityException {
+        return getDelegate().getJobNames();
+    }
+
+    @Override
+    public int getJobInstanceCount(final String jobName) throws NoSuchJobException, JobSecurityException {
+        return getDelegate().getJobInstanceCount(jobName);
+    }
+
+    @Override
+    public List<JobInstance> getJobInstances(final String jobName, final int start, final int count) throws NoSuchJobException, JobSecurityException {
+        return getDelegate().getJobInstances(jobName, start, count);
+    }
+
+    @Override
+    public List<Long> getRunningExecutions(final String jobName) throws NoSuchJobException, JobSecurityException {
+        return getDelegate().getRunningExecutions(jobName);
+    }
+
+    @Override
+    public Properties getParameters(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return getDelegate().getParameters(executionId);
+    }
+
+    @Override
+    public long start(final String jobXMLName, final Properties jobParameters) throws JobStartException, JobSecurityException {
+        return getDelegate().start(jobXMLName, jobParameters);
+    }
+
+    @Override
+    public long restart(final long executionId, final Properties restartParameters) throws JobExecutionAlreadyCompleteException, NoSuchJobExecutionException, JobExecutionNotMostRecentException, JobRestartException, JobSecurityException {
+        return getDelegate().restart(executionId, restartParameters);
+    }
+
+    @Override
+    public void stop(final long executionId) throws NoSuchJobExecutionException, JobExecutionNotRunningException, JobSecurityException {
+        getDelegate().stop(executionId);
+    }
+
+    @Override
+    public void abandon(final long executionId) throws NoSuchJobExecutionException, JobExecutionIsRunningException, JobSecurityException {
+        getDelegate().abandon(executionId);
+    }
+
+    @Override
+    public JobInstance getJobInstance(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return getDelegate().getJobInstance(executionId);
+    }
+
+    @Override
+    public List<JobExecution> getJobExecutions(final JobInstance instance) throws NoSuchJobInstanceException, JobSecurityException {
+        return getDelegate().getJobExecutions(instance);
+    }
+
+    @Override
+    public JobExecution getJobExecution(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return getDelegate().getJobExecution(executionId);
+    }
+
+    @Override
+    public List<StepExecution> getStepExecutions(final long jobExecutionId) throws NoSuchJobExecutionException, JobSecurityException {
+        return getDelegate().getStepExecutions(jobExecutionId);
+    }
+
+    /**
+     * Returns the delegate {@link JobOperator}. This cannot return {@code null}.
+     *
+     * @return the delegate job operator
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected JobOperator getDelegate() {
+        return JobOperatorContext.getJobOperatorContext().getJobOperator();
+    }
+}

--- a/jberet-core/src/main/java/org/jberet/operations/JobOperatorImpl.java
+++ b/jberet-core/src/main/java/org/jberet/operations/JobOperatorImpl.java
@@ -14,54 +14,16 @@ package org.jberet.operations;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
 import java.util.ServiceLoader;
-import java.util.Set;
 import javax.batch.operations.BatchRuntimeException;
-import javax.batch.operations.JobExecutionAlreadyCompleteException;
-import javax.batch.operations.JobExecutionIsRunningException;
-import javax.batch.operations.JobExecutionNotMostRecentException;
-import javax.batch.operations.JobExecutionNotRunningException;
 import javax.batch.operations.JobOperator;
-import javax.batch.operations.JobRestartException;
-import javax.batch.operations.JobSecurityException;
-import javax.batch.operations.JobStartException;
-import javax.batch.operations.NoSuchJobException;
-import javax.batch.operations.NoSuchJobExecutionException;
-import javax.batch.operations.NoSuchJobInstanceException;
-import javax.batch.runtime.BatchStatus;
-import javax.batch.runtime.JobExecution;
-import javax.batch.runtime.JobInstance;
-import javax.batch.runtime.StepExecution;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.transaction.InvalidTransactionException;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
 
-import org.jberet._private.BatchLogger;
 import org.jberet._private.BatchMessages;
-import org.jberet.creation.ArchiveXmlLoader;
-import org.jberet.creation.ArtifactFactoryWrapper;
-import org.jberet.job.model.Job;
-import org.jberet.repository.ApplicationAndJobName;
 import org.jberet.repository.JobRepository;
-import org.jberet.runtime.JobExecutionImpl;
-import org.jberet.runtime.JobInstanceImpl;
-import org.jberet.runtime.context.JobContextImpl;
-import org.jberet.runtime.runner.JobExecutionRunner;
-import org.jberet.spi.ArtifactFactory;
 import org.jberet.spi.BatchEnvironment;
-import org.jberet.spi.PropertyKey;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
-import static org.jberet._private.BatchMessages.MESSAGES;
-
-public class JobOperatorImpl implements JobOperator {
+public class JobOperatorImpl extends AbstractJobOperator implements JobOperator {
 
     private static final PrivilegedAction<BatchEnvironment> loaderAction = new PrivilegedAction<BatchEnvironment>() {
         @Override
@@ -76,334 +38,24 @@ public class JobOperatorImpl implements JobOperator {
 
     final JobRepository repository;
     private final BatchEnvironment batchEnvironment;
-    private final ArtifactFactory artifactFactory;
 
     public JobOperatorImpl() throws BatchRuntimeException {
-        final BatchEnvironment batchEnvironment;
-        if (WildFlySecurityManager.isChecking()) {
-            batchEnvironment = AccessController.doPrivileged(loaderAction);
-        } else {
-            batchEnvironment = loaderAction.run();
-        }
+        this(WildFlySecurityManager.isChecking() ? AccessController.doPrivileged(loaderAction) : loaderAction.run());
+    }
 
+    public JobOperatorImpl(final BatchEnvironment batchEnvironment) throws BatchRuntimeException {
         if (batchEnvironment == null) {
             throw BatchMessages.MESSAGES.batchEnvironmentNotFound();
         }
         this.batchEnvironment = batchEnvironment;
-        artifactFactory = new ArtifactFactoryWrapper(batchEnvironment.getArtifactFactory());
-        repository = batchEnvironment.getJobRepository();
+        repository = this.batchEnvironment.getJobRepository();
         if (repository == null) {
             throw BatchMessages.MESSAGES.jobRepositoryRequired();
         }
     }
 
     @Override
-    public long start(final String jobXMLName, final Properties jobParameters) throws JobStartException, JobSecurityException {
-        final Job jobDefined = ArchiveXmlLoader.loadJobXml(jobXMLName, batchEnvironment.getClassLoader(),
-                new ArrayList<Job>(), batchEnvironment.getJobXmlResolver());
-        return start(jobDefined, jobParameters);
-    }
-
-    /**
-     * Starts a pre-configured {@link Job} instance, with job parameters.
-     *
-     * @param jobDefined a pre-configured job
-     * @param jobParameters job parameters for the current job execution
-     * @return job execution id as a long number
-     * @throws JobStartException if failed to start the job
-     * @throws JobSecurityException if failed to start the job due to security permission
-     *
-     * @see org.jberet.job.model.JobBuilder
-     * @since 1.2.0
-     */
-    public long start(final Job jobDefined, final Properties jobParameters) throws JobStartException, JobSecurityException {
-        final ClassLoader classLoader = batchEnvironment.getClassLoader();
-        final String applicationName = getApplicationName();
-        repository.addJob(new ApplicationAndJobName(applicationName, jobDefined.getId()), jobDefined);
-        try {
-            return invokeTransaction(new TransactionInvocation<Long>() {
-                @Override
-                public Long invoke() throws JobStartException, JobSecurityException {
-                    final JobInstanceImpl jobInstance = repository.createJobInstance(jobDefined, applicationName, classLoader);
-                    return startJobExecution(jobInstance, jobParameters, null);
-                }
-            });
-        } catch (InvalidTransactionException e) {
-            throw new JobStartException(e);
-        } catch (SystemException e) {
-            throw new JobStartException(e);
-        }
-    }
-
-    @Override
-    public void stop(final long executionId) throws NoSuchJobExecutionException,
-            JobExecutionNotRunningException, JobSecurityException {
-        final JobExecutionImpl jobExecution = (JobExecutionImpl) getJobExecution(executionId);
-        final BatchStatus s = jobExecution.getBatchStatus();
-        if (s == BatchStatus.STOPPED || s == BatchStatus.FAILED || s == BatchStatus.ABANDONED ||
-                s == BatchStatus.COMPLETED) {
-            throw MESSAGES.jobExecutionNotRunningException(executionId, s);
-        } else if (s == BatchStatus.STOPPING) {
-            //in process of stopping, do nothing
-        } else {
-            jobExecution.setBatchStatus(BatchStatus.STOPPING);
-            jobExecution.stop();
-        }
-    }
-
-    @Override
-    public Set<String> getJobNames() throws JobSecurityException {
-        return repository.getJobNames();
-    }
-
-    @Override
-    public int getJobInstanceCount(final String jobName) throws NoSuchJobException, JobSecurityException {
-        if (jobName == null) {
-            throw MESSAGES.noSuchJobException(null);
-        }
-        final int count = repository.getJobInstanceCount(jobName);
-        if (count == 0 && !repository.jobExists(jobName)) {
-            throw MESSAGES.noSuchJobException(jobName);
-        }
-        return count;
-    }
-
-    @Override
-    public List<JobInstance> getJobInstances(final String jobName, final int start, final int count) throws NoSuchJobException, JobSecurityException {
-        if (jobName == null) {
-            throw MESSAGES.noSuchJobException(null);
-        }
-        final List<JobInstance> instances = repository.getJobInstances(jobName);
-        final int size = instances.size();
-        if (size == 0 && !repository.jobExists(jobName)) {
-            throw MESSAGES.noSuchJobException(jobName);
-        }
-        return instances.subList(Math.min(start, size), Math.min(start + count, size));
-    }
-
-    @Override
-    public List<Long> getRunningExecutions(final String jobName) throws NoSuchJobException, JobSecurityException {
-        if (jobName == null) {
-            throw MESSAGES.noSuchJobException(null);
-        }
-        final List<Long> result = repository.getRunningExecutions(jobName);
-        if (result.size() == 0 && !repository.jobExists(jobName)) {
-            throw MESSAGES.noSuchJobException(jobName);
-        }
-        return result;
-    }
-
-    @Override
-    public Properties getParameters(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
-        return getJobExecution(executionId).getJobParameters();
-    }
-
-    @Override
-    public long restart(final long executionId, final Properties restartParameters) throws JobExecutionAlreadyCompleteException,
-            NoSuchJobExecutionException, JobExecutionNotMostRecentException, JobRestartException, JobSecurityException {
-        final JobExecutionImpl originalToRestart = (JobExecutionImpl) getJobExecution(executionId);
-
-        if (Job.UNRESTARTABLE.equals(originalToRestart.getRestartPosition())) {
-            throw MESSAGES.unrestartableJob(originalToRestart.getJobName(), executionId);
-        }
-
-        final BatchStatus previousStatus = originalToRestart.getBatchStatus();
-        if (previousStatus == BatchStatus.FAILED || previousStatus == BatchStatus.STOPPED) {
-            return restartFailedOrStopped(executionId, originalToRestart, restartParameters);
-        }
-
-        if (previousStatus == BatchStatus.COMPLETED) {
-            throw MESSAGES.jobExecutionAlreadyCompleteException(executionId);
-        }
-
-        if (previousStatus == BatchStatus.ABANDONED) {
-            throw MESSAGES.jobRestartException(executionId, previousStatus);
-        }
-
-        //previousStatus is now one of STARTING, STARTED, or STOPPING
-        final String restartMode = restartParameters != null ? restartParameters.getProperty(PropertyKey.RESTART_MODE) : null;
-        if (PropertyKey.RESTART_MODE_STRICT.equalsIgnoreCase(restartMode)) {
-            throw MESSAGES.jobRestartException(executionId, previousStatus);
-        } else if(restartMode == null || restartMode.equalsIgnoreCase(PropertyKey.RESTART_MODE_DETECT)) {
-            //to detect if originalToRestart had crashed or not
-            if (originalToRestart.getJobInstance().getUnsubstitutedJob() != null) {
-                throw MESSAGES.restartRunningExecution(executionId, originalToRestart.getJobName(), previousStatus, restartMode);
-            }
-        } else if (!restartMode.equalsIgnoreCase(PropertyKey.RESTART_MODE_FORCE)) {
-            throw MESSAGES.invalidRestartMode(executionId, originalToRestart.getJobName(), previousStatus, restartMode,
-                    Arrays.asList(PropertyKey.RESTART_MODE_DETECT, PropertyKey.RESTART_MODE_FORCE, PropertyKey.RESTART_MODE_STRICT));
-        }
-
-        //update batch status in originalToRestart to FAILED, for previousStatus STARTING, STARTED, or STOPPING
-        BatchLogger.LOGGER.markAsFailed(executionId, originalToRestart.getJobName(), previousStatus, restartMode);
-        originalToRestart.setBatchStatus(BatchStatus.FAILED);
-        repository.updateJobExecution(originalToRestart, false, false);
-        return restartFailedOrStopped(executionId, originalToRestart, restartParameters);
-    }
-
-    @Override
-    public void abandon(final long executionId) throws
-            NoSuchJobExecutionException, JobExecutionIsRunningException, JobSecurityException {
-        final JobExecutionImpl jobExecution = (JobExecutionImpl) getJobExecution(executionId);
-        final BatchStatus batchStatus = jobExecution.getBatchStatus();
-        if (batchStatus == BatchStatus.COMPLETED ||
-                batchStatus == BatchStatus.FAILED ||
-                batchStatus == BatchStatus.STOPPED ||
-                batchStatus == BatchStatus.ABANDONED) {
-            jobExecution.setBatchStatus(BatchStatus.ABANDONED);
-            repository.updateJobExecution(jobExecution, false, false);
-
-            final JobInstanceImpl jobInstance = jobExecution.getJobInstance();
-            if (jobInstance != null) {
-                jobInstance.setUnsubstitutedJob(null);
-            }
-        } else {
-            throw MESSAGES.jobExecutionIsRunningException(executionId);
-        }
-    }
-
-    @Override
-    public JobInstance getJobInstance(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
-        final JobExecutionImpl jobExecution = (JobExecutionImpl) getJobExecution(executionId);
-        return jobExecution.getJobInstance();
-    }
-
-    @Override
-    public List<JobExecution> getJobExecutions(final JobInstance instance) throws
-            NoSuchJobInstanceException, JobSecurityException {
-        if (instance == null) {
-            throw MESSAGES.noSuchJobInstance(null);
-        }
-        return repository.getJobExecutions(instance);
-    }
-
-    @Override
-    public JobExecution getJobExecution(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
-        final JobExecution jobExecution = repository.getJobExecution(executionId);
-        if (jobExecution == null) {
-            throw MESSAGES.noSuchJobExecution(executionId);
-        }
-        return jobExecution;
-    }
-
-    @Override
-    public List<StepExecution> getStepExecutions(final long jobExecutionId) throws
-            NoSuchJobExecutionException, JobSecurityException {
-        final List<StepExecution> stepExecutions = repository.getStepExecutions(jobExecutionId, batchEnvironment.getClassLoader());
-        if (stepExecutions.isEmpty()) {
-            //check if the jobExecutionId passed in points to a valid JobExecution
-            //since no step executions under this jobExecutionId was found, it's likely this job execution may not exist
-            //getJobExecution() call will throw NoSuchJobExecutionException for non-exist jobExecutionId.
-            getJobExecution(jobExecutionId);
-        }
-        return stepExecutions;
-    }
-
-    /**
-     * Restarts a FAILED or STOPPED job execution.
-     *
-     * @param executionId the old job execution id to restart
-     * @param originalToRestart the old job execution
-     * @param restartParameters restart job parameters
-     * @return the new job execution id
-     * @throws JobExecutionNotMostRecentException
-     * @throws JobRestartException
-     */
-    private long restartFailedOrStopped(final long executionId, final JobExecutionImpl originalToRestart, final Properties restartParameters)
-            throws JobExecutionNotMostRecentException, JobRestartException {
-        final JobInstanceImpl jobInstance = originalToRestart.getJobInstance();
-        final List<JobExecution> executions = getJobExecutions(jobInstance);
-        final JobExecution mostRecentExecution = executions.get(executions.size() - 1);
-        if (executionId != mostRecentExecution.getExecutionId()) {
-            throw MESSAGES.jobExecutionNotMostRecentException(executionId, jobInstance.getInstanceId());
-        }
-
-        // the job may not have been loaded, e.g., when the restart is performed in a new JVM
-        final String jobName = originalToRestart.getJobName();
-        Properties oldJobParameters = originalToRestart.getJobParameters();
-        Job jobDefined = jobInstance.getUnsubstitutedJob();
-        if (jobDefined == null) {
-            final ApplicationAndJobName applicationAndJobName = new ApplicationAndJobName(jobInstance.getApplicationName(), jobName);
-            jobDefined = repository.getJob(applicationAndJobName);
-
-            if (jobDefined == null) {
-                String jobXmlName = null;
-                if (oldJobParameters != null) {
-                    jobXmlName = oldJobParameters.getProperty(Job.JOB_XML_NAME);
-                }
-                if (jobXmlName == null) {
-                    jobXmlName = jobName;
-                } else {
-                    oldJobParameters.remove(Job.JOB_XML_NAME);
-                    if (!oldJobParameters.propertyNames().hasMoreElements()) {
-                        oldJobParameters = null;
-                    }
-                }
-                jobDefined = ArchiveXmlLoader.loadJobXml(jobXmlName, batchEnvironment.getClassLoader(), new ArrayList<Job>(), batchEnvironment.getJobXmlResolver());
-                repository.addJob(applicationAndJobName, jobDefined);
-            }
-            jobInstance.setUnsubstitutedJob(jobDefined);
-        }
-
-        try {
-            final Properties combinedProperties;
-            if (oldJobParameters != null) {
-                if (restartParameters == null) {
-                    combinedProperties = oldJobParameters;
-                } else {
-                    combinedProperties = new Properties(oldJobParameters);
-                    for (final String k : restartParameters.stringPropertyNames()) {
-                        combinedProperties.setProperty(k, restartParameters.getProperty(k));
-                    }
-                }
-            } else {
-                combinedProperties = restartParameters;
-            }
-
-            return invokeTransaction(new TransactionInvocation<Long>() {
-                @Override
-                public Long invoke() throws JobStartException, JobSecurityException {
-                    return startJobExecution(jobInstance, combinedProperties, originalToRestart);
-                }
-            });
-        } catch (final Exception e) {
-            throw new JobRestartException(e);
-        }
-    }
-
-    private long startJobExecution(final JobInstanceImpl jobInstance, final Properties jobParameters, final JobExecutionImpl originalToRestart) throws JobStartException, JobSecurityException {
-        final JobExecutionImpl jobExecution = repository.createJobExecution(jobInstance, jobParameters);
-        final JobContextImpl jobContext = new JobContextImpl(jobExecution, originalToRestart, artifactFactory, repository, batchEnvironment);
-
-        final JobExecutionRunner jobExecutionRunner = new JobExecutionRunner(jobContext);
-        jobContext.getBatchEnvironment().submitTask(jobExecutionRunner);
-        return jobExecution.getExecutionId();
-    }
-
-    private String getApplicationName() {
-        try {
-            return InitialContext.doLookup("java:app/AppName");
-        } catch (NamingException e) {
-            return null;
-        }
-    }
-
-    private <T> T invokeTransaction(final TransactionInvocation<T> transactionInvocation) throws SystemException, InvalidTransactionException {
-        final TransactionManager tm = batchEnvironment.getTransactionManager();
-        final Transaction tx = tm.suspend();
-        if (tx != null) {
-            try {
-                return transactionInvocation.invoke();
-            } finally {
-                tm.resume(tx);
-            }
-        }
-        // No transaction in process
-        return transactionInvocation.invoke();
-    }
-
-    private static interface TransactionInvocation<T> {
-
-        T invoke() throws JobStartException, JobSecurityException;
+    protected BatchEnvironment getBatchEnvironment() {
+        return batchEnvironment;
     }
 }

--- a/jberet-core/src/main/java/org/jberet/spi/ContextClassLoaderJobOperatorContextSelector.java
+++ b/jberet-core/src/main/java/org/jberet/spi/ContextClassLoaderJobOperatorContextSelector.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.spi;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.jberet._private.BatchMessages;
+import org.jberet.util.Assertions;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * Uses the {@linkplain Thread#getContextClassLoader() context class loader} to find the {@link JobOperatorContext} for.
+ * If a context os not found for the loader the {@linkplain DefaultJobOperatorContextSelector default context} will be
+ * used.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("unused")
+public class ContextClassLoaderJobOperatorContextSelector implements JobOperatorContextSelector {
+    private final JobOperatorContextSelector defaultSelector;
+    private final ConcurrentMap<ClassLoader, JobOperatorContext> contexts = new ConcurrentHashMap<ClassLoader, JobOperatorContext>();
+    private final PrivilegedAction<JobOperatorContext> action = new PrivilegedAction<JobOperatorContext>() {
+        @Override
+        public JobOperatorContext run() {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            if (cl != null) {
+                final JobOperatorContext context = contexts.get(cl);
+                if (context != null) {
+                    return context;
+                }
+            }
+            return defaultSelector.getJobOperatorContext();
+        }
+    };
+
+    /**
+     * Creates a new selector.
+     *
+     * @param defaultSelector the default selector, cannot be null
+     */
+    public ContextClassLoaderJobOperatorContextSelector(final JobOperatorContextSelector defaultSelector) {
+        this.defaultSelector = Assertions.notNull(defaultSelector, "defaultSelector");
+    }
+
+    @Override
+    public JobOperatorContext getJobOperatorContext() {
+        if (WildFlySecurityManager.isChecking()) {
+            return AccessController.doPrivileged(action);
+        }
+        return action.run();
+    }
+
+    /**
+     * Registers a context with the class loader.
+     *
+     * @param classLoader the class loader to register the context with
+     * @param context     the context that should be used on the class loader
+     */
+    public void registerContext(final ClassLoader classLoader, final JobOperatorContext context) {
+        if (contexts.putIfAbsent(classLoader, context) != null) {
+            // Don't allow a duplicate to be registered
+            throw BatchMessages.MESSAGES.classLoaderAlreadyRegistered(classLoader);
+        }
+    }
+
+    /**
+     * Attempts to remove the context registered for the class loader. If the class loader does not have a registered
+     * context {@code null} will be returned.
+     *
+     * @param classLoader the class loader to remove the context for
+     *
+     * @return the removed context or {@code null} if the class loader did not have a registered context
+     */
+    public JobOperatorContext unregisterContext(final ClassLoader classLoader) {
+        return contexts.remove(classLoader);
+    }
+
+    /**
+     * Attempts to remove the specific context registered for the class loader. If the context is not registered with
+     * the specified context {@code false} will be returned.
+     *
+     * @param classLoader the class loader to remove the context for
+     * @param context     the context which should be removed
+     *
+     * @return {@code true} if the context was removed, otherwise {@code false}
+     */
+    public boolean unregisterContext(final ClassLoader classLoader, final JobOperatorContext context) {
+        return contexts.remove(classLoader, context);
+    }
+}

--- a/jberet-core/src/main/java/org/jberet/spi/DefaultJobOperatorContextSelector.java
+++ b/jberet-core/src/main/java/org/jberet/spi/DefaultJobOperatorContextSelector.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.spi;
+
+import org.jberet.operations.JobOperatorImpl;
+
+/**
+ * A default context selector.
+ * <p>
+ * This will require that a {@link BatchEnvironment} service file is available on the class path. This may not work
+ * well in a Java EE environment, but should work fine in a Java SE environment.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("WeakerAccess")
+public class DefaultJobOperatorContextSelector implements JobOperatorContextSelector {
+    private final JobOperatorContext jobOperatorContext;
+
+    /**
+     * Creates a new default context selector
+     */
+    public DefaultJobOperatorContextSelector() {
+        jobOperatorContext = JobOperatorContext.create(new JobOperatorImpl());
+    }
+
+    @Override
+    public JobOperatorContext getJobOperatorContext() {
+        return jobOperatorContext;
+    }
+}

--- a/jberet-core/src/main/java/org/jberet/spi/JobOperatorContext.java
+++ b/jberet-core/src/main/java/org/jberet/spi/JobOperatorContext.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.spi;
+
+import javax.batch.operations.JobOperator;
+
+import org.jberet.operations.JobOperatorImpl;
+import org.jberet.util.Assertions;
+
+/**
+ * A context on which the {@link JobOperator} can be found.
+ * <p>
+ * If no {@linkplain #setJobOperatorContextSelector(JobOperatorContextSelector) selector} is set the
+ * {@link DefaultJobOperatorContextSelector} will be used. Do note that this does require the implementation to provide
+ * a {@link BatchEnvironment} via a {@linkplain java.util.ServiceLoader service loader}.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("unused")
+public abstract class JobOperatorContext {
+
+    private static volatile JobOperatorContextSelector SELECTOR = null;
+
+    private static class DefaultHolder {
+        // In some cases the BatchEnvironment may not be provided via a ServiceLoader. The
+        // DefaultJobOperatorContextSelector assumes a ServiceLoader will be used to find the BatchEnvironment resulting
+        // in initialization errors if not found. We get around this by lazily loading the default selector.
+        static final JobOperatorContextSelector DEFAULT = new DefaultJobOperatorContextSelector();
+    }
+
+    /**
+     * Returns the current context based on the selector.
+     *
+     * @return the current context
+     */
+    public static JobOperatorContext getJobOperatorContext() {
+        JobOperatorContextSelector selector = SELECTOR;
+        if (selector == null) {
+            selector = DefaultHolder.DEFAULT;
+        }
+        return selector.getJobOperatorContext();
+    }
+
+    /**
+     * Creates a new context based on the environment.
+     *
+     * @param batchEnvironment the batch environment to create the context for, cannot be {@code null}
+     *
+     * @return the new context
+     */
+    public static JobOperatorContext create(final BatchEnvironment batchEnvironment) {
+        final JobOperator jobOperator = new JobOperatorImpl(Assertions.notNull(batchEnvironment, "batchEnvironment"));
+        return new JobOperatorContext() {
+            @Override
+            public JobOperator getJobOperator() {
+                return jobOperator;
+            }
+        };
+    }
+
+    /**
+     * Creates a new context which returns the job operator.
+     *
+     * @param jobOperator the job operator this context should return, cannot be {@code null}
+     *
+     * @return the new context
+     */
+    public static JobOperatorContext create(final JobOperator jobOperator) {
+        Assertions.notNull(jobOperator, "jobOperator");
+        return new JobOperatorContext() {
+            @Override
+            public JobOperator getJobOperator() {
+                return jobOperator;
+            }
+        };
+    }
+
+    /**
+     * Allows the selector for the {@link JobOperatorContext} to be set. If the parameter is {@code null} the default
+     * selector will be used.
+     *
+     * @param selector the selector to use
+     */
+    public static void setJobOperatorContextSelector(final JobOperatorContextSelector selector) {
+        SELECTOR = selector;
+    }
+
+    /**
+     * Returns the {@link JobOperator} for this current context.
+     *
+     * @return the job operator
+     */
+    public abstract JobOperator getJobOperator();
+}

--- a/jberet-core/src/main/java/org/jberet/spi/JobOperatorContextSelector.java
+++ b/jberet-core/src/main/java/org/jberet/spi/JobOperatorContextSelector.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.spi;
+
+/**
+ * A selector for the {@link JobOperatorContext}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface JobOperatorContextSelector {
+
+    /**
+     * Returns the job operator context for the current environment.
+     *
+     * @return the job operator context
+     */
+    JobOperatorContext getJobOperatorContext();
+}

--- a/jberet-core/src/main/java/org/jberet/util/Assertions.java
+++ b/jberet-core/src/main/java/org/jberet/util/Assertions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.util;
+
+import org.jberet._private.BatchMessages;
+
+/**
+ * Assertion utilities.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Assertions {
+
+    /**
+     * If the value is {@code null} an {@link IllegalArgumentException} is thrown, otherwise the value is returned.
+     *
+     * @param value the value to check
+     * @param name  the name of the parameter being checked
+     * @param <T>   the type
+     *
+     * @return the value if not {@code null}
+     */
+    public static <T> T notNull(final T value, final String name) {
+        if (value == null) {
+            throw BatchMessages.MESSAGES.nullVar(name);
+        }
+        return value;
+    }
+}

--- a/jberet-core/src/main/resources/META-INF/services/javax.batch.operations.JobOperator
+++ b/jberet-core/src/main/resources/META-INF/services/javax.batch.operations.JobOperator
@@ -1,2 +1,2 @@
-org.jberet.operations.JobOperatorImpl
+org.jberet.operations.DelegatingJobOperator
 

--- a/test-apps/common/src/main/java/org/jberet/testapps/common/AbstractIT.java
+++ b/test-apps/common/src/main/java/org/jberet/testapps/common/AbstractIT.java
@@ -27,6 +27,7 @@ import org.jberet.job.model.Job;
 import org.jberet.operations.JobOperatorImpl;
 import org.jberet.runtime.JobExecutionImpl;
 import org.jberet.runtime.StepExecutionImpl;
+import org.jberet.spi.JobOperatorContext;
 import org.junit.Assert;
 import org.junit.Before;
 
@@ -65,7 +66,9 @@ abstract public class AbstractIT {
     @Before
     public void before() throws Exception {
         if (jobOperator == null) {
-            jobOperator = (JobOperatorImpl) BatchRuntime.getJobOperator();
+            // The BatchRuntime.getJobOperator() returns the DelegatingJobOperator, using the context will give us
+            // access to the default JobOperatorImpl.
+            jobOperator = (JobOperatorImpl) JobOperatorContext.getJobOperatorContext().getJobOperator();
         }
     }
 


### PR DESCRIPTION
…plementations. Added a JobOperatorContext and context selector to allow the environment to control the JobOperator used. Use a new DelegatingJobOperator as the default implemented returned by the BatchRuntime.getJobOperator().

This is the 1.2 version for https://github.com/jberet/jsr352/pull/88. This passed the TCK, I did have a failure in the throttle test, but I don't think it's related.