### PR TITLE
Remove the usage of commons-exec in favor of ProcessBuilder API. Fix …

### DIFF
--- a/jberet-support/pom.xml
+++ b/jberet-support/pom.xml
@@ -168,12 +168,6 @@
             <artifactId>jasperreports</artifactId>
         </dependency>
 
-        <!-- OsCommandBatchlet dependencies -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-exec</artifactId>
-        </dependency>
-
         <!-- JAX-RS dependencies -->
         <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>

--- a/jberet-support/src/main/java/org/jberet/support/_private/SupportLogger.java
+++ b/jberet-support/src/main/java/org/jberet/support/_private/SupportLogger.java
@@ -12,6 +12,8 @@
 
 package org.jberet.support._private;
 
+import java.util.List;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -41,9 +43,9 @@ public interface SupportLogger extends BasicLogger {
     @LogMessage(level = Logger.Level.WARN)
     void failToWriteWorkbook(@Cause Throwable th, String workbook, String resource);
 
-    @Message(id = 60504, value = "About to run command %s, with arguments %s, in working directory %s")
+    @Message(id = 60504, value = "About to run command %s, in working directory %s")
     @LogMessage(level = Logger.Level.INFO)
-    void runCommand(String command, String args, String workingDir);
+    void runCommand(List<String> cmd, String workingDir);
 
     @Message(id = 60505, value = "JDBC batch update count: %s")
     @LogMessage(level = Logger.Level.WARN)

--- a/jberet-support/src/main/java/org/jberet/support/_private/SupportMessages.java
+++ b/jberet-support/src/main/java/org/jberet/support/_private/SupportMessages.java
@@ -12,6 +12,7 @@
 
 package org.jberet.support._private;
 
+import java.util.Collection;
 import javax.batch.operations.BatchRuntimeException;
 
 import com.fasterxml.jackson.core.JsonLocation;
@@ -91,5 +92,11 @@ public interface SupportMessages {
 
     @Message(id = 60024, value = "Failed to look up resource by name: %s")
     BatchRuntimeException failToLookup(@Cause Throwable throwable, String lookupName);
+
+    @Message(id = 60025, value = "Process has exited with an error code %d. %s")
+    String processExecutionFailure(int exitCode, final Collection<String> cmd);
+
+    @Message(id = 60026, value = "Directory %s is invalid.")
+    BatchRuntimeException invalidDirectory(String dir);
 
 }

--- a/jberet-support/src/main/java/org/jberet/support/io/OsCommandBatchlet.java
+++ b/jberet-support/src/main/java/org/jberet/support/io/OsCommandBatchlet.java
@@ -13,23 +13,20 @@
 package org.jberet.support.io;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.batch.api.BatchProperty;
 import javax.batch.api.Batchlet;
+import javax.batch.operations.BatchRuntimeException;
 import javax.batch.runtime.context.StepContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.exec.CommandLine;
-import org.apache.commons.exec.DefaultExecuteResultHandler;
-import org.apache.commons.exec.DefaultExecutor;
-import org.apache.commons.exec.ExecuteException;
-import org.apache.commons.exec.ExecuteStreamHandler;
-import org.apache.commons.exec.ExecuteWatchdog;
-import org.apache.commons.exec.ShutdownHookProcessDestroyer;
 import org.jberet.support._private.SupportLogger;
 import org.jberet.support._private.SupportMessages;
 
@@ -37,13 +34,13 @@ import org.jberet.support._private.SupportMessages;
  * This batchlet runs a native OS command in a sub-process asynchronously.
  * Main features supported include:
  * <ul>
- *     <li>specify command and arguments as a single line;
- *     <li>specify command and arguments as a comma-separated list of items, for easy handling of spaces in file paths;
- *     <li>custom working directory;
- *     <li>specify timeout as seconds so the OS commnad can timeout
- *     <li>the OS command process can be stopped;
- *     <li>passing custom environment variables;
- *     <li>map non-zero exit code from OS command process.
+ * <li>specify command and arguments as a single line;
+ * <li>specify command and arguments as a comma-separated list of items, for easy handling of spaces in file paths;
+ * <li>custom working directory;
+ * <li>specify timeout as seconds so the OS commnad can timeout
+ * <li>the OS command process can be stopped;
+ * <li>passing custom environment variables;
+ * <li>map non-zero exit code from OS command process.
  * </ul>
  */
 @Named
@@ -145,18 +142,23 @@ public class OsCommandBatchlet implements Batchlet {
     protected Map<String, String> environment;
 
     /**
-     * Fully-qualified name of a class that implements {@code org.apache.commons.exec.ExecuteStreamHandler},
+     * Fully-qualified name of a class that implements {@link StreamHandler},
      * which handles the input and output of the subprocess.
      *
-     * @see "org.apache.commons.exec.ExecuteStreamHandler"
+     * @see StreamHandler
      */
     @Inject
     @BatchProperty
     protected Class streamHandler;
 
-    private ExecuteWatchdog watchdog;
+    private final Object lock = new Object();
 
-    private volatile boolean isStopped;
+    // Guarded by lock
+    private StreamHandler handler;
+    // Guarded by lock
+    private Process process;
+    // Guarded by lock
+    private boolean isStopped;
 
     /**
      * {@inheritDoc}
@@ -173,57 +175,87 @@ public class OsCommandBatchlet implements Batchlet {
      */
     @Override
     public String process() throws Exception {
-        final DefaultExecutor executor = new DefaultExecutor();
-        final CommandLine commandLineObj;
+        final List<String> cmd = new ArrayList<>();
         if (commandLine != null) {
-            commandLineObj = CommandLine.parse(commandLine);
+            cmd.addAll(parse(commandLine));
         } else {
             if (commandArray == null) {
                 throw SupportMessages.MESSAGES.invalidReaderWriterProperty(null, null, "commandArray");
             } else if (commandArray.isEmpty()) {
                 throw SupportMessages.MESSAGES.invalidReaderWriterProperty(null, commandArray.toString(), "commandArray");
             }
-            commandLineObj = new CommandLine(commandArray.get(0));
-            final int len = commandArray.size();
-            if (len > 1) {
-                for (int i = 1; i < len; i++) {
-                    commandLineObj.addArgument(commandArray.get(i));
+            cmd.addAll(commandArray);
+        }
+
+        // Create the process builder based on the commands
+        final ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+
+        // Set the working directory for the process
+        if (workingDir != null) {
+            processBuilder.directory(workingDir);
+        }
+        // Set the environment variables for the process
+        if (environment != null) {
+            processBuilder.environment().putAll(environment);
+        }
+
+        // Validate the working directory
+        File workingDirectory = processBuilder.directory();
+        if (workingDirectory == null) {
+            workingDirectory = new File(".");
+        }
+        if (!workingDirectory.exists()) {
+            throw SupportMessages.MESSAGES.invalidDirectory(workingDirectory.getAbsolutePath());
+        }
+        SupportLogger.LOGGER.runCommand(cmd, workingDirectory.getAbsolutePath());
+
+        // Start the process and the stream handler if defined
+        final Process process = processBuilder.start();
+        StreamHandler handler = null;
+        if (streamHandler != null) {
+            handler = (StreamHandler) streamHandler.newInstance();
+            handler.setProcessErrorStream(process.getErrorStream());
+            handler.setProcessInputStream(process.getOutputStream());
+            handler.setProcessOutputStream(process.getInputStream());
+            handler.start();
+        }
+        synchronized (lock) {
+            this.process = process;
+            this.handler = handler;
+        }
+
+        try {
+
+            if (timeoutSeconds > 0) {
+                // If defined wait for the number of seconds, if the process has not terminated the process should be
+                // destroyed
+                if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
                 }
             }
-        }
+            // Wait for the process to exit
+            final int exitCode = process.waitFor();
 
-        if (workingDir != null) {
-            executor.setWorkingDirectory(workingDir);
-        }
-        if (streamHandler != null) {
-            executor.setStreamHandler((ExecuteStreamHandler) streamHandler.newInstance());
-        }
-
-        SupportLogger.LOGGER.runCommand(commandLineObj.getExecutable(),
-                Arrays.toString(commandLineObj.getArguments()), executor.getWorkingDirectory().getAbsolutePath());
-
-        if (commandOkExitValues != null) {
-            executor.setExitValues(commandOkExitValues);
-        }
-
-        watchdog = new ExecuteWatchdog(timeoutSeconds > 0 ? timeoutSeconds * 1000 : ExecuteWatchdog.INFINITE_TIMEOUT);
-        executor.setWatchdog(watchdog);
-
-        executor.setProcessDestroyer(new ShutdownHookProcessDestroyer());
-        final DefaultExecuteResultHandler resultHandler = new DefaultExecuteResultHandler();
-        executor.execute(commandLineObj, environment, resultHandler);
-        resultHandler.waitFor();
-
-        final ExecuteException exception = resultHandler.getException();
-        if (exception != null) {
-            stepContext.setExitStatus(String.valueOf(resultHandler.getExitValue()));
-            if (!isStopped) {
-                throw exception;
-            } else {
-                SupportLogger.LOGGER.warn("", exception);
+            // If the exit code was not expected or not a normal exit code (0 is considered normal) fail.
+            if (isFailure(exitCode) || exitCode != 0) {
+                stepContext.setExitStatus(String.valueOf(exitCode));
+                final boolean started;
+                synchronized (lock) {
+                    started = !isStopped;
+                }
+                // Throw an exception if started otherwise log the error
+                if (started) {
+                    throw new BatchRuntimeException(SupportMessages.MESSAGES.processExecutionFailure(exitCode, cmd));
+                } else {
+                    SupportLogger.LOGGER.warn(SupportMessages.MESSAGES.processExecutionFailure(exitCode, cmd));
+                }
+            }
+            return String.valueOf(exitCode);
+        } finally {
+            if (handler != null) {
+                handler.stop();
             }
         }
-        return String.valueOf(resultHandler.getExitValue());
     }
 
     /**
@@ -235,9 +267,65 @@ public class OsCommandBatchlet implements Batchlet {
      */
     @Override
     public void stop() throws Exception {
-        if (watchdog != null) {
-            isStopped = true;
-            watchdog.destroyProcess();
+        synchronized (lock) {
+            try {
+                if (process != null) {
+                    isStopped = true;
+                    // Destroy the process. The waitFor() in the process() should handle the rest of the processing.
+                    process.destroyForcibly();
+                }
+            } finally {
+                process = null;
+                if (handler != null) {
+                    handler.stop();
+                }
+            }
         }
+    }
+
+    private boolean isFailure(final int exitCode) {
+        if (commandOkExitValues == null) {
+            return false;
+        }
+        for (int okValue : commandOkExitValues) {
+            if (okValue == exitCode) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Parses a command into a collection of strings for the {@link ProcessBuilder}.
+     *
+     * @param cmd the command to parse
+     *
+     * @return the parsed commands or an empty list
+     */
+    private static Collection<String> parse(final String cmd) {
+        if (cmd == null) return Collections.emptyList();
+        final Collection<String> arguments = new ArrayList<>();
+        boolean inDoubleQuote = false;
+        boolean inSingleQuote = false;
+        StringBuilder sb = new StringBuilder();
+        for (char c : cmd.toCharArray()) {
+            if (c == '"') {
+                inDoubleQuote = !inSingleQuote && !inDoubleQuote;
+            } else if (c == '\'') {
+                inSingleQuote = !inSingleQuote && !inDoubleQuote;
+            } else if (c == ' ' && !inDoubleQuote && !inSingleQuote) {
+                arguments.add(sb.toString());
+                sb.setLength(0);
+                continue;
+            }
+            sb.append(c);
+        }
+        if (inDoubleQuote || inSingleQuote) {
+            throw new IllegalArgumentException("Missing trailing quote in: " + cmd);
+        }
+        if (sb.length() > 0) {
+            arguments.add(sb.toString());
+        }
+        return arguments;
     }
 }

--- a/jberet-support/src/main/java/org/jberet/support/io/StreamHandler.java
+++ b/jberet-support/src/main/java/org/jberet/support/io/StreamHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.jberet.support.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A handler which allows the streams from a {@link Process} to be consumed.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface StreamHandler {
+
+    /**
+     * Sets the {@link OutputStream} to handle {@code stdin}.
+     *
+     * @param stdin the output stream that handles standard input
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void setProcessInputStream(OutputStream stdin) throws IOException;
+
+    /**
+     * Sets the {@link InputStream} to handle {@code stdout}.
+     *
+     * @param stdout the input stream that handles standard out
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void setProcessOutputStream(InputStream stdout) throws IOException;
+
+    /**
+     * Sets the {@link InputStream} to handle {@code stderr}.
+     *
+     * @param stderr the input stream that handles standard error
+     *
+     * @throws IOException if an I/O error occurs
+     */
+    void setProcessErrorStream(InputStream stderr) throws IOException;
+
+    /**
+     * Start handling of the streams.
+     */
+    void start();
+
+    /**
+     * Stop handling the streams.
+     */
+    void stop();
+}

--- a/jberet-support/src/test/java/org/jberet/support/io/OsCommandBatchletTest.java
+++ b/jberet-support/src/test/java/org/jberet/support/io/OsCommandBatchletTest.java
@@ -12,22 +12,25 @@
 
 package org.jberet.support.io;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.StepExecution;
 
-import org.apache.commons.exec.ExecuteStreamHandler;
 import org.jberet.operations.JobOperatorImpl;
 import org.jberet.runtime.JobExecutionImpl;
 import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link OsCommandBatchlet}.
@@ -35,6 +38,7 @@ import static org.junit.Assert.assertEquals;
  * @since 1.3.0.Beta5
  */
 public class OsCommandBatchletTest {
+    private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
     public static final String jobName = "org.jberet.support.io.OsCommandBatchletTest";
     public static final JobOperator jobOperator = new JobOperatorImpl();
 
@@ -48,24 +52,40 @@ public class OsCommandBatchletTest {
     public void simpleCommands() throws Exception {
         // run echo command, and should complete successfully with process exit code 0.
         final Properties jobParams = new Properties();
-        jobParams.setProperty("commandLine", "echo This is echo from osCommandBatchlet");
-        runCommand(jobParams, BatchStatus.COMPLETED, String.valueOf(0));
+        String cmd;
+        if (IS_WINDOWS) {
+            cmd = "cmd.exe /C echo This is echo from osCommandBatchlet";
+        } else {
+            cmd = "echo This is echo from osCommandBatchlet";
+        }
+        jobParams.setProperty("commandLine", cmd);
+        runCommand(jobParams, BatchStatus.COMPLETED, true);
 
         // run echo command, passing the command as comma-separated list,
         // and setting custom working directory and timeout.
         // The command should complete successfully with process exit code 0.
         jobParams.clear();
-        jobParams.setProperty("commandArray", "echo, abc, xyz, 123");
+        if (IS_WINDOWS) {
+            cmd = "cmd.exe, /C, echo, abc, xyz, 123";
+        } else {
+            cmd = "echo, abc, xyz, 123";
+        }
+        jobParams.setProperty("commandArray", cmd);
         jobParams.setProperty("workingDir", System.getProperty("java.io.tmpdir"));
         jobParams.setProperty("timeoutSeconds", String.valueOf(600));
-        runCommand(jobParams, BatchStatus.COMPLETED, String.valueOf(0));
+        runCommand(jobParams, BatchStatus.COMPLETED, true);
 
         // run cd command, setting the process exit code for successful completion to 999999.
         // The job execution should fail, since the process exit code 0 does not match 999999.
         jobParams.clear();
-        jobParams.setProperty("commandLine", "cd ..");
+        if (IS_WINDOWS) {
+            cmd = "cmd.exe /C cd ..";
+        } else {
+            cmd = "cd ..";
+        }
+        jobParams.setProperty("commandLine", cmd);
         jobParams.setProperty("commandOkExitValues", String.valueOf(999999));
-        runCommand(jobParams, BatchStatus.FAILED, String.valueOf(0));
+        runCommand(jobParams, BatchStatus.FAILED, true);
     }
 
     /**
@@ -78,68 +98,99 @@ public class OsCommandBatchletTest {
     public void streamHandler() throws Exception {
         // run echo command, and should complete successfully with process exit code 0.
         final Properties jobParams = new Properties();
-        jobParams.setProperty("commandLine", "echo This is echo from osCommandBatchlet");
+        final String cmd;
+        if (IS_WINDOWS) {
+            cmd = "cmd.exe /C echo This is echo from osCommandBatchlet";
+        } else {
+            cmd = "echo This is echo from osCommandBatchlet";
+        }
+        jobParams.setProperty("commandLine", cmd);
         jobParams.setProperty("streamHandler", "org.jberet.support.io.OsCommandBatchletTest$NoopStreamHandler");
-        runCommand(jobParams, BatchStatus.COMPLETED, String.valueOf(0));
+        runCommand(jobParams, BatchStatus.COMPLETED, true);
+        assertFalse("Expected the stream handler to be stopped.", NoopStreamHandler.started.get());
     }
 
     /**
-     * Runs {@code top} command, which continuously displays OS process info.
-     * By setting a timeout, the {@code top} process should be aborted after timeout,
-     * and so the job execution should fail, and the batch exit status is set to
-     * the process exit code (143, interrupted).
+     * Runs {@code sleep} ({@code ping} on Windows) command, which will block for at least 10 seconds. The batch exit
+     * status is set to the process exit code.
      *
      * @throws Exception upon errors
      */
     @Test
     public void timeout() throws Exception {
         final Properties jobParams = new Properties();
-        jobParams.setProperty("commandLine", "top");
+        if (IS_WINDOWS) {
+            jobParams.setProperty("commandLine", "cmd.exe /C ping -n 10 127.0.0.1");
+        } else {
+            jobParams.setProperty("commandLine", "sleep 10");
+        }
         jobParams.setProperty("timeoutSeconds", String.valueOf(5));
-        runCommand(jobParams, BatchStatus.FAILED, String.valueOf(143));
+        runCommand(jobParams, BatchStatus.FAILED, false);
     }
 
     /**
-     * Runs {@code top} command, which continuously displays OS process info.
-     * The job execution is then stopped, which means the {@code top} command
-     * should also be stopped.  The batch exit status is set to the process
-     * exit code (143).
+     * Runs {@code sleep} ({@code ping} on Windows) command, which will block for at least 10 seconds. The batch exit
+     * status is set to the process exit code.
      *
      * @throws Exception upon errors
      */
     @Test
     public void stop() throws Exception {
         final Properties jobParams = new Properties();
-        jobParams.setProperty("commandLine", "top");
+        if (IS_WINDOWS) {
+            jobParams.setProperty("commandLine", "cmd.exe /C ping -n 10 127.0.0.1");
+        } else {
+            jobParams.setProperty("commandLine", "sleep 10");
+        }
         final long jobExecutionId = jobOperator.start(jobName, jobParams);
         final JobExecutionImpl jobExecution = (JobExecutionImpl) jobOperator.getJobExecution(jobExecutionId);
 
         Thread.sleep(3000);
+        assertEquals(String.format("Job is not started. Exit status %s", jobExecution.getExitStatus()),
+                BatchStatus.STARTED, jobExecution.getBatchStatus());
         jobOperator.stop(jobExecutionId);
         Thread.sleep(2000);
-        checkJobExecution(jobExecution, BatchStatus.STOPPED, String.valueOf(143));
+        checkJobExecution(jobExecution, BatchStatus.STOPPED, false);
     }
 
     protected void runCommand(final Properties jobParams,
                               final BatchStatus expectedBatchStatus,
-                              final String expectedExitStatus) throws Exception {
+                              final boolean expectSuccess) throws Exception {
         final long jobExecutionId = jobOperator.start(jobName, jobParams);
         final JobExecutionImpl jobExecution = (JobExecutionImpl) jobOperator.getJobExecution(jobExecutionId);
         jobExecution.awaitTermination(5, TimeUnit.MINUTES);
-        checkJobExecution(jobExecution, expectedBatchStatus, expectedExitStatus);
+        checkJobExecution(jobExecution, expectedBatchStatus, expectSuccess);
     }
 
+    /**
+     * Checks the job execution.
+     * <p>
+     * Assumes there is only one step and that the step exit status is either {@code 0} or not {@code 0}. An exit code
+     * of {@code 0} is assumed to be successful any other value is expected to be a failure. The {@code expectSuccess}
+     * should be {@code true} if a {@code 0} exit code is expected.
+     * </p>
+     *
+     * @param jobExecution        if the job execution used to get the steps
+     * @param expectedBatchStatus the expected batch status
+     * @param expectSuccess       {@code true} if the exist status (the processes exit code) should be {@code 0}, otherwise
+     *                            {@code false}
+     */
     protected void checkJobExecution(final JobExecutionImpl jobExecution,
                                      final BatchStatus expectedBatchStatus,
-                                     final String expectedExitStatus) {
+                                     final boolean expectSuccess) {
         assertEquals(expectedBatchStatus, jobExecution.getBatchStatus());
         final List<StepExecution> stepExecutions = jobExecution.getStepExecutions();
         assertEquals(1, stepExecutions.size());
         final StepExecution stepExecution = stepExecutions.get(0);
-        assertEquals(expectedExitStatus, stepExecution.getExitStatus());
+        if (expectSuccess) {
+            assertEquals("0", stepExecution.getExitStatus());
+        } else {
+            assertNotEquals("0", stepExecution.getExitStatus());
+        }
     }
 
-    public static final class NoopStreamHandler implements ExecuteStreamHandler {
+    public static final class NoopStreamHandler implements StreamHandler {
+        static final AtomicBoolean started = new AtomicBoolean();
 
         @Override
         public void setProcessInputStream(final OutputStream os) throws IOException {
@@ -157,13 +208,15 @@ public class OsCommandBatchletTest {
         }
 
         @Override
-        public void start() throws IOException {
-
+        public void start() {
+            if (!started.compareAndSet(false, true)) {
+                throw new RuntimeException("There was an attempt to restart a StreamHandler before it's been stopped");
+            }
         }
 
         @Override
-        public void stop() throws IOException {
-
+        public void stop() {
+            started.set(false);
         }
     }
 


### PR DESCRIPTION
…OsCommandBatchletTest to work on with other OS's.

https://issues.jboss.org/browse/JBERET-345

Removes the usage of the Apache commons-exec API. When running the tests on Windows the {{destroy()}} method didn't seem to destroy the process. Using the new {{Process.destroyForcibly()}} method introduced in Java 7 seems to fix this issue. With this I made a change to use the {{ProcessBuilder}} instead.

I've also fixed the test to ensure it passes on all operating systems.