### PR TITLE
ChunkRunner spawning a thousands of chunk-checkpoint-timer threads

### DIFF
--- a/jberet-core/src/main/java/org/jberet/runtime/runner/ChunkRunner.java
+++ b/jberet-core/src/main/java/org/jberet/runtime/runner/ChunkRunner.java
@@ -504,7 +504,7 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
 
     private void beginCheckpoint(final ProcessingInfo processingInfo) throws Exception {
         if (checkpointPolicy.equals("item") && timeLimit > 0) {
-            processingInfo.expiresAt = timeLimit * 1_000_000 + System.nanoTime();
+            processingInfo.expiresAt = timeLimit * 1_000_000L + System.nanoTime();
         }
         //if chunk is already RETRYING, do not change it to RUNNING
         if (processingInfo.chunkState == ChunkState.TO_RETRY) {
@@ -850,7 +850,7 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
 
         private void reset(final int timeLimit) {
             count = 0;
-            expiresAt = timeLimit * 1_000_000 + System.nanoTime();
+            expiresAt = timeLimit * 1_000_000L + System.nanoTime();
             itemState = ItemState.RUNNING;
             chunkState = ChunkState.RUNNING;
             failurePoint = null;

--- a/jberet-core/src/main/java/org/jberet/runtime/runner/ChunkRunner.java
+++ b/jberet-core/src/main/java/org/jberet/runtime/runner/ChunkRunner.java
@@ -13,8 +13,6 @@ package org.jberet.runtime.runner;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.batch.api.chunk.CheckpointAlgorithm;
 import javax.batch.api.chunk.ItemProcessor;
@@ -313,7 +311,7 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
                         processingInfo.chunkState == ChunkState.RETRYING ||
                         processingInfo.chunkState == ChunkState.TO_END_RETRY) {
                     if (processingInfo.chunkState == ChunkState.TO_START_NEW || processingInfo.chunkState == ChunkState.TO_END_RETRY) {
-                        processingInfo.reset();
+                        processingInfo.reset(timeLimit);
                     }
                     //if during Chunk RETRYING, and an item is skipped, the ut is still active so no need to begin a new one
                     if (tm.getStatus() != Status.STATUS_ACTIVE) {
@@ -505,16 +503,8 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
     }
 
     private void beginCheckpoint(final ProcessingInfo processingInfo) throws Exception {
-        if (checkpointPolicy.equals("item")) {
-            if (timeLimit > 0) {
-                final Timer timer = new Timer("chunk-checkpoint-timer", true);
-                timer.schedule(new TimerTask() {
-                    @Override
-                    public void run() {
-                        processingInfo.timerExpired = true;
-                    }
-                }, timeLimit * 1000);
-            }
+        if (checkpointPolicy.equals("item") && timeLimit > 0) {
+            processingInfo.expiresAt = System.currentTimeMillis() + ( timeLimit * 1000 );
         }
         //if chunk is already RETRYING, do not change it to RUNNING
         if (processingInfo.chunkState == ChunkState.TO_RETRY) {
@@ -542,7 +532,7 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
                 return true;
             }
             if (timeLimit > 0) {
-                return processingInfo.timerExpired;
+                return processingInfo.timerExpired();
             }
             return false;
         }
@@ -838,7 +828,7 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
          */
         int count;
 
-        boolean timerExpired;
+        long expiresAt;
         ItemState itemState = ItemState.RUNNING;
         ChunkState chunkState = ChunkState.TO_START_NEW;
 
@@ -858,9 +848,9 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
          */
         Integer failurePoint;
 
-        private void reset() {
+        private void reset(final int timeLimit) {
             count = 0;
-            timerExpired = false;
+            expiresAt = System.currentTimeMillis() + ( timeLimit * 1000 );
             itemState = ItemState.RUNNING;
             chunkState = ChunkState.RUNNING;
             failurePoint = null;
@@ -871,12 +861,16 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
                     itemState == ItemState.TO_RETRY_READ || itemState == ItemState.TO_RETRY_PROCESS ||
                     itemState == ItemState.TO_RETRY_WRITE;
         }
+        
+        private boolean timerExpired() {
+        	return System.currentTimeMillis() > expiresAt;
+        }
 
         @Override
         public String toString() {
             final StringBuilder sb = new StringBuilder("ProcessingInfo{");
             sb.append("count=").append(count);
-            sb.append(", timerExpired=").append(timerExpired);
+            sb.append(", timerExpired=").append(timerExpired());
             sb.append(", itemState=").append(itemState);
             sb.append(", chunkState=").append(chunkState);
             sb.append(", checkpointPosition=").append(checkpointPosition);

--- a/jberet-core/src/main/java/org/jberet/runtime/runner/ChunkRunner.java
+++ b/jberet-core/src/main/java/org/jberet/runtime/runner/ChunkRunner.java
@@ -504,7 +504,7 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
 
     private void beginCheckpoint(final ProcessingInfo processingInfo) throws Exception {
         if (checkpointPolicy.equals("item") && timeLimit > 0) {
-            processingInfo.expiresAt = System.currentTimeMillis() + ( timeLimit * 1000 );
+            processingInfo.expiresAt = timeLimit * 1_000_000 + System.nanoTime();
         }
         //if chunk is already RETRYING, do not change it to RUNNING
         if (processingInfo.chunkState == ChunkState.TO_RETRY) {
@@ -850,7 +850,7 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
 
         private void reset(final int timeLimit) {
             count = 0;
-            expiresAt = System.currentTimeMillis() + ( timeLimit * 1000 );
+            expiresAt = timeLimit * 1_000_000 + System.nanoTime();
             itemState = ItemState.RUNNING;
             chunkState = ChunkState.RUNNING;
             failurePoint = null;
@@ -863,7 +863,7 @@ public final class ChunkRunner extends AbstractRunner<StepContextImpl> implement
         }
         
         private boolean timerExpired() {
-        	return System.currentTimeMillis() > expiresAt;
+        	return System.nanoTime() > expiresAt;
         }
 
         @Override


### PR DESCRIPTION
Hi,
today I found that if time-limit was set to a big number of seconds my JVM struggled keeping track of thousands of threads named `chunk-checkpoint-timer` on certain job.

Investigating on the source code I found that `org.jberet.runtime.runner.ChunkRunner` class, when `time-limit` attribute on chunk tag was set bigger than 0, scheduled a timed thread just to update a boolean flag

```java
            if (timeLimit > 0) {
                final Timer timer = new Timer("chunk-checkpoint-timer", true);
                timer.schedule(new TimerTask() {
                    @Override
                    public void run() {
                        processingInfo.timerExpired = true;
                    }
                }, timeLimit * 1000);
            }
```
I don't know if can be an intended behavior, but `java.util.Timer` class was not officially but practically deprecated in favor of `java.util.concurrent.ScheduledThreadPoolExecutor`. In any case here I tried to totally bypass the usage of threads and checking the expiration of the chunk only with a simpler check on the current millis with `System.currentTimeMillis()`.