### PR TITLE
JBERET-458 getRunningExecutions() should look in cache as fallback.

### DIFF
--- a/jberet-core/src/main/java/org/jberet/_private/BatchLogger.java
+++ b/jberet-core/src/main/java/org/jberet/_private/BatchLogger.java
@@ -13,6 +13,7 @@
 package org.jberet._private;
 
 import java.sql.Connection;
+import java.util.List;
 import javax.batch.runtime.BatchStatus;
 
 import org.jboss.logging.BasicLogger;
@@ -151,5 +152,9 @@ public interface BatchLogger extends BasicLogger {
     @Message(id = 31, value = "Problem finalizing partition execution in step execution %s")
     @LogMessage(level = Logger.Level.WARN)
     void problemFinalizingPartitionExecution(@Cause Throwable cause, long stepExecutionId);
+
+    @Message(id = 32, value = "Failed to get running executions for job %s; instead got cached executions: %s")
+    @LogMessage(level = Logger.Level.WARN)
+    void failedGetRunningExecutions(@Cause Throwable cause, String jobName, List<Long> jobExecutionIds);
 
 }

--- a/jberet-core/src/main/java/org/jberet/repository/AbstractPersistentRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/AbstractPersistentRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2013-2018 Red Hat, Inc. and/or its affiliates.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@
 package org.jberet.repository;
 
 import java.lang.ref.ReferenceQueue;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.JobInstance;
 import javax.batch.runtime.StepExecution;
@@ -174,5 +176,29 @@ public abstract class AbstractPersistentRepository extends AbstractRepository im
             }
         }
         return null;
+    }
+
+    /**
+     * Gets the list of running job execution ids from the cache.
+     * The result may be used as a supplement to that from the persistence store.
+     *
+     * @param jobName the job name
+     * @return list of running job execution ids
+     */
+    List<Long> getCachedRunningExecutions(final String jobName) {
+        final List<Long> result = new ArrayList<Long>();
+
+        for (final Map.Entry<Long, SoftReference<JobExecutionImpl, Long>> e : jobExecutions.entrySet()) {
+            final JobExecutionImpl jobExecution = e.getValue().get();
+            if (jobExecution != null) {
+                if (jobExecution.getJobName().equals(jobName)) {
+                    final BatchStatus s = jobExecution.getBatchStatus();
+                    if (s == BatchStatus.STARTING || s == BatchStatus.STARTED) {
+                        result.add(e.getKey());
+                    }
+                }
+            }
+        }
+        return result;
     }
 }


### PR DESCRIPTION
JBEAP(7.2.z): https://issues.jboss.org/browse/JBEAP-17944
Upstream: https://issues.jboss.org/browse/JBERET-458
Upstream commit: https://github.com/jberet/jsr352/commit/b02f5999b565f3bc859766500f6d5ab37c2afba3