### PR TITLE
Proposal to support toBuilder in JBeret model.

### DIFF
--- a/jberet-core/src/main/java/org/jberet/job/model/Job.java
+++ b/jberet-core/src/main/java/org/jberet/job/model/Job.java
@@ -13,6 +13,10 @@ package org.jberet.job.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.jberet.job.model.Properties.toJavaUtilProperties;
 
 /**
  * Corresponds to {@code jsl:Job} type, the root element of job XML.
@@ -157,5 +161,28 @@ public final class Job extends InheritableJobElement implements Serializable, Pr
      */
     public List<InheritableJobElement> getInheritingJobElements() {
         return inheritingJobElements;
+    }
+
+    public JobBuilder toBuilder() {
+        final JobBuilder jobBuilder = new JobBuilder(this.getId());
+        jobBuilder.properties(toJavaUtilProperties(this.getProperties()))
+                  .restartable(this.getRestartableBoolean());
+
+        if (this.getListeners() != null) {
+            this.getListeners()
+                .getListeners()
+                .forEach(refArtifact -> jobBuilder
+                    .listener(refArtifact.getRef(), toJavaUtilProperties(refArtifact.getProperties())));
+        }
+
+        for (JobElement jobElement : this.jobElements) {
+
+            if (jobElement instanceof Step) {
+                jobBuilder.step(((Step) jobElement).toBuilder().build());
+            }
+
+        }
+
+        return jobBuilder;
     }
 }

--- a/jberet-core/src/main/java/org/jberet/job/model/Step.java
+++ b/jberet-core/src/main/java/org/jberet/job/model/Step.java
@@ -10,6 +10,8 @@
 
 package org.jberet.job.model;
 
+import static org.jberet.job.model.Properties.toJavaUtilProperties;
+
 /**
  * Corresponds to {@code jsl:Step} job element type in job XML.
  */
@@ -160,5 +162,20 @@ public final class Step extends InheritableJobElement implements PropertiesHolde
      */
     void setPartition(final Partition partition) {
         this.partition = partition;
+    }
+
+    public StepBuilder toBuilder() {
+        final StepBuilder stepBuilder = new StepBuilder(this.getId());
+
+        stepBuilder.properties(toJavaUtilProperties(this.getProperties()))
+                   .startLimit(this.getStartLimitInt())
+                   .allowStartIfComplete(this.getAllowStartIfCompleteBoolean())
+                   .next(this.getAttributeNext());
+
+        if (this.getBatchlet() != null) {
+            stepBuilder.batchlet(this.getBatchlet().getRef(), toJavaUtilProperties(this.getBatchlet().getProperties()));
+        }
+
+        return stepBuilder;
     }
 }

--- a/jberet-core/src/test/java/org/jberet/job/model/JobBuilderTest.java
+++ b/jberet-core/src/test/java/org/jberet/job/model/JobBuilderTest.java
@@ -1,0 +1,57 @@
+package org.jberet.job.model;
+
+import org.jberet.creation.ArchiveXmlLoader;
+import org.jberet.tools.MetaInfBatchJobsJobXmlResolver;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class JobBuilderTest {
+    @Test
+    public void jobToBuilder() {
+        final Job job = loadJob("sample-job.xml");
+        final JobBuilder jobBuilder = job.toBuilder();
+        final Job jobClone = jobBuilder.build();
+
+        assertEquals(job.getId(), jobClone.getId());
+        assertEquals(job.getRestartableBoolean(), jobClone.getRestartableBoolean());
+
+        assertNotNull(job.getListeners());
+        assertEquals(job.getListeners().getListeners().size(), jobClone.getListeners().getListeners().size());
+        for (int i = 0; i < job.getListeners().getListeners().size(); i++) {
+            RefArtifact refArtifact = job.getListeners().getListeners().get(i);
+            RefArtifact refArtifactClone = job.getListeners().getListeners().get(i);
+            assertEquals(refArtifact.getRef(), refArtifactClone.getRef());
+            assertEquals(refArtifact.getProperties(), refArtifactClone.getProperties());
+            assertEquals(refArtifact.getScript(), refArtifactClone.getScript());
+        }
+
+        assertNotNull(job.getJobElements());
+        //assertEquals(job.getJobElements().size(), jobClone.getJobElements().size());
+        for (int i = 0; i < job.getJobElements().size(); i++) {
+            JobElement jobElement = job.getJobElements().get(i);
+            JobElement jobElementClone = job.getJobElements().get(i);
+            assertEquals(jobElement.getId(), jobElementClone.getId());
+
+            if (jobElement instanceof Step) {
+                Step step = (Step) jobElement;
+                Step stepClone = (Step) jobElementClone;
+                assertEquals(step.getProperties(), stepClone.getProperties());
+                assertEquals(step.getStartLimit(), stepClone.getStartLimit());
+
+                if (step.getBatchlet() != null) {
+                    assertEquals(step.getBatchlet().getRef(), stepClone.getBatchlet().getRef());
+                    assertEquals(step.getBatchlet().getProperties(), stepClone.getBatchlet().getProperties());
+                    assertEquals(step.getBatchlet().getScript(), stepClone.getBatchlet().getScript());
+                }
+            }
+        }
+    }
+
+    private static Job loadJob(final String jobName) {
+        return ArchiveXmlLoader.loadJobXml(jobName, JobMergerTest.class.getClassLoader(), new ArrayList<>(), new MetaInfBatchJobsJobXmlResolver());
+    }
+}


### PR DESCRIPTION
Hey @chengfang, what do you think about supporting `toBuilder` in the JBeret model?

The purpose of the PR is to replace the cloning code by calling `toBuilder`, modify if required and `build` again. Also, this would allow to pass in the model in the Quarkus recorders by using the builders, and drop any required changes to the API of the runtime model, by exposing/adding API's (no args constructor) or changing methods behaviours (`getTransitionElements` cannot throw `IllegalStateException`). Hopefully, this would allow to move forward with https://github.com/quarkusio/quarkus/issues/1505.

This is not the full change, just a PoC to see how it could look like. 

//cc @jmartisk 