### PR TITLE
downgrade jackson version a bit from 2.13.2.1 to 2.13.2, since jackso…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <version.org.jboss.jandex>2.0.5.Final</version.org.jboss.jandex>
         <version.org.mapstruct>1.3.1.Final</version.org.mapstruct>
         <version.net.sf.supercsv>2.4.0</version.net.sf.supercsv>
-        <version.com.fasterxml.jackson>2.13.2.1</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.2</version.com.fasterxml.jackson>
         <version.org.mongodb.mongo-java-driver>3.8.0</version.org.mongodb.mongo-java-driver>
 
         <version.org.infinispan>11.0.3.Final</version.org.infinispan>


### PR DESCRIPTION
…n-databind has 2.13.2.1 but other jackson artifacts like jackson-core does not have this micro version

Modification to the previous dependabot PR https://github.com/jberet/jsr352/pull/203