### PR TITLE
Bump derby from 10.10.2.0 to 10.14.2.0 in /test-apps/purgeJdbcReposit…

### DIFF
--- a/test-apps/purgeJdbcRepository/pom.xml
+++ b/test-apps/purgeJdbcRepository/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
-            <version>10.10.2.0</version>
+            <version>10.14.2.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
…ory (#244)

Bumps derby from 10.10.2.0 to 10.14.2.0.

---
updated-dependencies:
- dependency-name: org.apache.derby:derby
  dependency-type: direct:development
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>