### PR TITLE
Enable Support to get DB Username/Password from enivonment variable for jberet.properties #367

### DIFF
--- a/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
@@ -146,23 +146,11 @@ public final class JdbcRepository extends AbstractPersistentRepository {
             this.dbUrl = dbUrl;
             final String dbUser = configProperties.getProperty(DB_USER_KEY);
             if (dbUser != null) {
-                if (dbUser.startsWith("${")){
-                    final String dbPasswordFromEnvVar = parseValuefromEnvVariables(dbUser);
-                    dbProperties.setProperty("user", dbPasswordFromEnvVar);
-                }
-                else {
-                    dbProperties.setProperty("user", dbUser.trim());
-                }
+                dbProperties.setProperty("user", dbUser.trim());
             }
             final String dbPassword = configProperties.getProperty(DB_PASSWORD_KEY);
             if (dbPassword != null) {
-                if (dbPassword.startsWith("${")){
-                    final String dbPasswordFromEnvVar = parseValuefromEnvVariables(dbPassword);
-                    dbProperties.setProperty("password", dbPasswordFromEnvVar);
-                }
-                else {
-                    dbProperties.setProperty("password", dbPassword.trim());
-                }
+                dbProperties.setProperty("password", dbPassword.trim());
             }
             final String s = configProperties.getProperty(DB_PROPERTIES_KEY);
             if (s != null) {

--- a/jberet-se/jberet.properties
+++ b/jberet-se/jberet.properties
@@ -1,5 +1,5 @@
 #Updated properties
-#Wed Sep 27 00:04:51 CEST 2023
+#Sat Sep 23 01:08:00 CEST 2023
 db-password=SOME_PASSWORD
 db-properties=
 db-url=jdbc\:h2\:./target/jberet-repo

--- a/jberet-se/pom.xml
+++ b/jberet-se/pom.xml
@@ -25,6 +25,10 @@ SPDX-License-Identifier: EPL-2.0
     <name>jberet-se</name>
     <description>Jakarta Batch implementation classes specific to Java SE environment</description>
 
+    <properties>
+        <powermock.version>2.0.2</powermock.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jberet</groupId>
@@ -70,6 +74,18 @@ SPDX-License-Identifier: EPL-2.0
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/jberet-se/pom.xml
+++ b/jberet-se/pom.xml
@@ -75,18 +75,6 @@ SPDX-License-Identifier: EPL-2.0
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -99,6 +87,9 @@ SPDX-License-Identifier: EPL-2.0
                     <reuseForks>false</reuseForks>
                     <!-- This will work for now as Batlet1Test needs to run before JobDataTest, but this should be reworked -->
                     <runOrder>alphabetical</runOrder>
+                    <systemPropertyVariables>
+                        <SOME_USER>SOME_some</SOME_USER>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/jberet-se/src/main/java/org/jberet/se/BatchSEEnvironment.java
+++ b/jberet-se/src/main/java/org/jberet/se/BatchSEEnvironment.java
@@ -94,12 +94,8 @@ public final class BatchSEEnvironment implements BatchEnvironment {
                 }
             }
 
-            try {
-                this.resolveEnvironmentVariables(this.configProperties);
-            } catch (Exception e){
-                System.out.println("Exception is " + e);
-                throw SEBatchMessages.MESSAGES.failedToResolveConfig(e);
-            }
+            this.resolveEnvironmentVariables(this.configProperties);
+
 
         } else {
             SEBatchLogger.LOGGER.useDefaultJBeretConfig(CONFIG_FILE_NAME);
@@ -117,14 +113,20 @@ public final class BatchSEEnvironment implements BatchEnvironment {
         this.jobXmlResolver = new ChainedJobXmlResolver(userJobXmlResolvers, DEFAULT_JOB_XML_RESOLVERS);
     }
 
-    public static void resolveEnvironmentVariables(Properties configProperties){
+    void resolveEnvironmentVariables(Properties configProperties){
         String[] attributeNames = new String[]{"db-user", "db-password"};
         for (String attribute:attributeNames){
-            configProperties.setProperty(attribute, resolveAttribute(configProperties.getProperty(attribute)));
+
+            String rawValue = configProperties.getProperty(attribute);
+            try{
+                configProperties.setProperty(attribute, this.resolveAttribute(rawValue));
+            } catch (Exception e){
+                SEBatchLogger.LOGGER.warnAboutConfigValResolution(attribute, e.toString());
+            }
         }
     }
 
-    public static String resolveAttribute(String rawValue){
+    String resolveAttribute(String rawValue){
         Pattern configValuePattern = Pattern.compile("^\\$\\{(.+?)\\}$");
         Matcher matcher = configValuePattern.matcher(rawValue);
 

--- a/jberet-se/src/main/java/org/jberet/se/_private/SEBatchLogger.java
+++ b/jberet-se/src/main/java/org/jberet/se/_private/SEBatchLogger.java
@@ -34,4 +34,8 @@ public interface SEBatchLogger {
     @LogMessage(level = Logger.Level.ERROR)
     void usage(String[] args);
 
+    @Message(id = 50502,
+    value = "Following Exception Occured while resolving Config Values for variable %s, using raw values from Config file, Exception is as follows %s")
+    @LogMessage(level = Logger.Level.WARN)
+    void warnAboutConfigValResolution(String attribute, String e);
 }

--- a/jberet-se/src/main/java/org/jberet/se/_private/SEBatchMessages.java
+++ b/jberet-se/src/main/java/org/jberet/se/_private/SEBatchMessages.java
@@ -35,4 +35,7 @@ public interface SEBatchMessages {
 
     @Message(id = 50004, value = "The job %s did not complete with batch status %s, exit status %s.")
     BatchRuntimeException jobDidNotComplete(String jobId, BatchStatus batchStatus, String exitStatus);
+
+    @Message(id = 50005, value = "Exception occurred while trying to resolve configProperty values: ")
+    BatchRuntimeException failedToResolveConfig(@Cause Throwable th);
 }

--- a/jberet-se/src/main/java/org/jberet/se/_private/SEBatchMessages.java
+++ b/jberet-se/src/main/java/org/jberet/se/_private/SEBatchMessages.java
@@ -35,7 +35,4 @@ public interface SEBatchMessages {
 
     @Message(id = 50004, value = "The job %s did not complete with batch status %s, exit status %s.")
     BatchRuntimeException jobDidNotComplete(String jobId, BatchStatus batchStatus, String exitStatus);
-
-    @Message(id = 50005, value = "Exception occurred while trying to resolve configProperty values: ")
-    BatchRuntimeException failedToResolveConfig(@Cause Throwable th);
 }

--- a/jberet-se/src/test/java/org/jberet/se/BatchSEEnvironmentTest.java
+++ b/jberet-se/src/test/java/org/jberet/se/BatchSEEnvironmentTest.java
@@ -10,6 +10,11 @@
 
 package org.jberet.se;
 
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionHandler;
@@ -33,22 +38,15 @@ import static org.jberet.se.BatchSEEnvironment.THREAD_POOL_REJECTION_POLICY;
 import static org.jberet.se.BatchSEEnvironment.THREAD_POOL_TYPE;
 import static org.jberet.se.BatchSEEnvironment.THREAD_POOL_TYPE_CONFIGURED;
 import static org.jberet.se.BatchSEEnvironment.THREAD_POOL_TYPE_FIXED;
-import static org.powermock.api.mockito.PowerMockito.when;
 
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.wildfly.security.manager.WildFlySecurityManager;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({WildFlySecurityManager.class})
 public class BatchSEEnvironmentTest {
 
     @Before
     public void setUp(){
         System.setProperty("SOME_USERNAME", "USERNAME");
     }
+
     private BatchSEEnvironment batchEnvironment = new BatchSEEnvironment();
 
     @Test
@@ -176,24 +174,15 @@ public class BatchSEEnvironmentTest {
     }
 
     @Test
-    public void testResolveEnvironmentVariables() {
+    public void testResolveAttribute() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        BatchSEEnvironment batchSEObject = new BatchSEEnvironment();
 
-        PowerMockito.mockStatic(WildFlySecurityManager.class);
-        when(WildFlySecurityManager.getEnvPropertyPrivileged("MOCK", "Mock")).thenReturn("USERNAME1");
-
-        Assert.assertEquals(System.getProperty("SOME_USERNAME"), "USERNAME");
-        BatchSEEnvironment testBatchEnvironment = new BatchSEEnvironment();
-        Properties loadedPropeties = testBatchEnvironment.getBatchConfigurationProperties();
-        Assert.assertEquals("USERNAME1", loadedPropeties.getProperty("db-user"));
-//        Assert.assertEquals(loadedPropeties.getProperty("db-password"), "DEFAULT_PASSWORD");
-
-    }
-
-    @Test
-    public void testResolveAttribute() {
-        Assert.assertEquals(BatchSEEnvironment.resolveAttribute("CLEAR_TEXT_USER_OR_PASS"), "CLEAR_TEXT_USER_OR_PASS");
-        Assert.assertEquals(BatchSEEnvironment.resolveAttribute("${CLEAR_TEXT_USER_OR_PASS"), "${CLEAR_TEXT_USER_OR_PASS");
-        Assert.assertEquals(BatchSEEnvironment.resolveAttribute("${ONLY_ENV_NAME_WO_DEFAULT}"), null);
+        Assert.assertEquals(batchSEObject.resolveAttribute("CLEAR_TEXT_USER_OR_PASS"), "CLEAR_TEXT_USER_OR_PASS");
+        Assert.assertEquals(batchSEObject.resolveAttribute("${CLEAR_TEXT_USER_OR_PASS"), "${CLEAR_TEXT_USER_OR_PASS");
+        // Need a way to find set mock Environment Variable Values for following Tests. SHOULD RETURN VALUE FOR ENV VARIABLE 'ONLY_ENV_NAME_WO_DEFAULT'
+        Assert.assertEquals(batchSEObject.resolveAttribute("${SOME_USER}"), null);
+        // Should return the 'DEFAULT' value
+        Assert.assertEquals(batchSEObject.resolveAttribute("${ONLY_ENV_NAME_WO_DEFAULT:DEFAULT}"), null);
     }
 
     static class SimpleThreadFactory implements ThreadFactory {

--- a/jberet-se/src/test/resources/jberet.properties
+++ b/jberet-se/src/test/resources/jberet.properties
@@ -17,8 +17,8 @@ infinispan-xml =
 # Use the target directory to store the DB
 db-url = jdbc:h2:./target/jberet-repo
 #db-url = mongodb://localhost/testData
-db-user =
-db-password =
+db-user = ${SOME_USERNAME:DEFAULT_USERNAME}
+db-password = ${SOME_PASSWORD:DEFAULT_PASSWORD}
 db-properties =
 
 # Optional, prefix and suffix for jdbc job repository database table names.


### PR DESCRIPTION
This code creates the capability for jberet to read environment variables for dbUser and db-password when given as ${ENV_VAR_NAME:default_value}. If the value is given as plain text, then this value will be used as was being used before  