### PR TITLE
JBERET-452: Remove db-creds from exception message

### DIFF
--- a/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
@@ -1112,7 +1112,7 @@ public final class JdbcRepository extends AbstractPersistentRepository {
             try {
                 return DriverManager.getConnection(dbUrl, dbProperties);
             } catch (final Exception e) {
-                throw BatchMessages.MESSAGES.failToObtainConnection(e, dbUrl, dbProperties);
+                throw BatchMessages.MESSAGES.failToObtainConnection(e, dbUrl, "<db props> masked");
             }
         }
     }


### PR DESCRIPTION
Removing database-properties from exception message, as those might contain database-credentials.
See related issue #452