### PR TITLE
[JBERET-612] Fix class loading issue with ddl file in Quarkus dev mode

### DIFF
--- a/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
+++ b/jberet-core/src/main/java/org/jberet/repository/JdbcRepository.java
@@ -258,7 +258,7 @@ public final class JdbcRepository extends AbstractPersistentRepository {
             rs = countPartitionExecutionStatement.executeQuery();
         } catch (final SQLException e) {
             final String ddlFile = getDDLLocation(databaseProductName);
-            ddlResource = getClassLoader(false).getResourceAsStream(ddlFile);
+            ddlResource = getClassLoader(true).getResourceAsStream(ddlFile);
             if (ddlResource == null) {
                 throw BatchMessages.MESSAGES.failToLoadDDL(ddlFile);
             }


### PR DESCRIPTION
Use the class loader of the current thread to ensure the ddl file is found when running in Quarkus dev mode 
This fixes: https://github.com/quarkiverse/quarkus-jberet/issues/406#issuecomment-2992009204